### PR TITLE
gstreamer1.0-plugins-base: Add patch files for version 1.28.0

### DIFF
--- a/gstreamer1.0-plugins-base/0001-video-Add-support-for-NV12_Q08C-compressed-8-bit-for.patch
+++ b/gstreamer1.0-plugins-base/0001-video-Add-support-for-NV12_Q08C-compressed-8-bit-for.patch
@@ -1,0 +1,193 @@
+From 6a8d943d4b33f44437ba6cf674a6292ebe50a8b7 Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Thu, 29 Jan 2026 13:07:23 +0530
+Subject: [PATCH 1/3] video: Add support for NV12_Q08C (compressed 8-bit)
+ format
+
+Upstream-Status: Denied [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9712]
+
+Signed-off-by: Bala Sai Kosuri <bkosuri@qti.qualcomm.com>
+---
+ gst-libs/gst/video/video-format.c   | 23 +++++++++++++++++++++
+ gst-libs/gst/video/video-format.h   | 10 ++++++++-
+ gst-libs/gst/video/video-info-dma.c |  1 +
+ gst-libs/gst/video/video-info.c     | 32 +++++++++++++++++++++++++++++
+ gst-libs/gst/video/video-scaler.c   |  1 +
+ tests/check/libs/video.c            |  4 ++++
+ 6 files changed, 70 insertions(+), 1 deletion(-)
+
+diff --git a/gst-libs/gst/video/video-format.c b/gst-libs/gst/video/video-format.c
+index 4092cfc..d731997 100644
+--- a/gst-libs/gst/video/video-format.c
++++ b/gst-libs/gst/video/video-format.c
+@@ -1723,6 +1723,24 @@ unpack_NV21 (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
+   }
+ }
+ 
++#define PACK_NV12_Q08C GST_VIDEO_FORMAT_NV12, unpack_NV12_Q08C, 1, pack_NV12_Q08C
++static void
++unpack_NV12_Q08C (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
++    gpointer dest, const gpointer data[GST_VIDEO_MAX_PLANES],
++    const gint stride[GST_VIDEO_MAX_PLANES], gint x, gint y, gint width)
++{
++  GST_FIXME ("Unpack NV12_Q08C is not yet supported.");
++}
++
++static void
++pack_NV12_Q08C (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
++    const gpointer src, gint sstride, gpointer data[GST_VIDEO_MAX_PLANES],
++    const gint stride[GST_VIDEO_MAX_PLANES], GstVideoChromaSite chroma_site,
++    gint y, gint width)
++{
++  GST_FIXME ("Pack NV12_Q08C is not yet supported.");
++}
++
+ #define PACK_AV12 GST_VIDEO_FORMAT_AYUV, unpack_AV12, 1, pack_AV12
+ static void
+ unpack_AV12 (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
+@@ -8269,6 +8287,9 @@ static const VideoFormat formats[] = {
+       PLANE0, OFFS0, SUB4444, PACK_BGR10A2_LE),
+   MAKE_RGB_LE_FORMAT (RGB10x2_LE, "raw video", DPTH10_10_10, PSTR444,
+       PLANE0, OFFS0, SUB4444, PACK_RGB10A2_LE),
++  MAKE_YUV_FORMAT (NV12_Q08C, "raw video",
++      GST_MAKE_FOURCC ('Q', '0', '8', 'C'), DPTH888, PSTR122, PLANE011,
++      OFFS001, SUB420, PACK_NV12_Q08C),
+ };
+ 
+ G_GNUC_END_IGNORE_DEPRECATIONS;
+@@ -8529,6 +8550,8 @@ gst_video_format_from_fourcc (guint32 fourcc)
+       return GST_VIDEO_FORMAT_VUYA;
+     case GST_MAKE_FOURCC ('A', 'R', '3', '0'):
+       return GST_VIDEO_FORMAT_BGR10A2_LE;
++    case GST_MAKE_FOURCC ('Q', '0', '8', 'C'):
++      return GST_VIDEO_FORMAT_NV12_Q08C;
+ 
+     default:
+       return GST_VIDEO_FORMAT_UNKNOWN;
+diff --git a/gst-libs/gst/video/video-format.h b/gst-libs/gst/video/video-format.h
+index 1bb9a2d..ed64d98 100644
+--- a/gst-libs/gst/video/video-format.h
++++ b/gst-libs/gst/video/video-format.h
+@@ -177,6 +177,7 @@ G_BEGIN_DECLS
+  * @GST_VIDEO_FORMAT_NV16_10LE40: Fully packed variant of NV16_10LE32 (Since: 1.28)
+  * @GST_VIDEO_FORMAT_BGR10x2_LE: packed 4:4:4 RGB (B-G-R-x), 10 bits for R/G/B channel and MSB 2 bits for padding (Since: 1.28)
+  * @GST_VIDEO_FORMAT_RGB10x2_LE: packed 4:4:4 RGB (R-G-B-x), 10 bits for R/G/B channel and MSB 2 bits for padding (Since: 1.28)
++ * @GST_VIDEO_FORMAT_NV12_Q08C: Qualcomm NV12 8bit compressed format
+  *
+  * Enum value describing the most common video formats.
+  *
+@@ -701,6 +702,13 @@ typedef enum {
+    */
+   GST_VIDEO_FORMAT_RGB10x2_LE,
+ 
++  /**
++   * GST_VIDEO_FORMAT_NV12_Q08C:
++   *
++   * Qualcomm NV12 8-bit compressed format.
++   */
++  GST_VIDEO_FORMAT_NV12_Q08C,
++
+   /* Update GST_VIDEO_FORMAT_LAST below when adding more formats here */
+ } GstVideoFormat;
+ 
+@@ -711,7 +719,7 @@ typedef enum {
+  *
+  * Since: 1.26
+  */
+-#define GST_VIDEO_FORMAT_LAST (GST_VIDEO_FORMAT_RGB10x2_LE + 1)
++#define GST_VIDEO_FORMAT_LAST (GST_VIDEO_FORMAT_NV12_Q08C + 1)
+ 
+ #define GST_VIDEO_MAX_PLANES 4
+ #define GST_VIDEO_MAX_COMPONENTS 4
+diff --git a/gst-libs/gst/video/video-info-dma.c b/gst-libs/gst/video/video-info-dma.c
+index 16c1cff..4a2c486 100644
+--- a/gst-libs/gst/video/video-info-dma.c
++++ b/gst-libs/gst/video/video-info-dma.c
+@@ -596,6 +596,7 @@ static const struct FormatMap
+   {GST_VIDEO_FORMAT_GRAY16_BE, DRM_FORMAT_R16 | DRM_FORMAT_BIG_ENDIAN, DRM_FORMAT_MOD_LINEAR},
+   {GST_VIDEO_FORMAT_NV16_10LE40, DRM_FORMAT_NV20, DRM_FORMAT_MOD_LINEAR},
+   {GST_VIDEO_FORMAT_P016_LE, DRM_FORMAT_P016, DRM_FORMAT_MOD_LINEAR},
++  {GST_VIDEO_FORMAT_NV12_Q08C, DRM_FORMAT_NV12, DRM_FORMAT_MOD_QCOM_COMPRESSED},
+ };
+ /* *INDENT-ON* */
+ 
+diff --git a/gst-libs/gst/video/video-info.c b/gst-libs/gst/video/video-info.c
+index 4d3f9a1..0c982d6 100644
+--- a/gst-libs/gst/video/video-info.c
++++ b/gst-libs/gst/video/video-info.c
+@@ -1398,6 +1398,38 @@ fill_planes (GstVideoInfo * info, gsize plane_size[GST_VIDEO_MAX_PLANES])
+       info->size = info->offset[1] + info->offset[1] / 2;
+       break;
+     }
++    case GST_VIDEO_FORMAT_NV12_Q08C:
++    {
++      gint y_plane_stride = 0, y_meta_stride = 0, y_meta_scanline = 0;
++      gint uv_plane_stride = 0, uv_meta_stride = 0, uv_meta_scanline = 0;
++      gint y_plane_scanline = 0, y_plane_size = 0, y_meta_size = 0;
++      gint uv_plane_scanline = 0, uv_plane_size = 0, uv_meta_size = 0;
++
++      y_plane_stride = GST_ROUND_UP_128 (width);
++      y_plane_scanline = GST_ROUND_UP_32 (height);
++      uv_plane_stride = GST_ROUND_UP_128 (width);
++      uv_plane_scanline = GST_ROUND_UP_32 (GST_ROUND_UP_2 (height) / 2);
++
++      y_meta_stride = GST_ROUND_UP_64 (GST_ROUND_UP_32 (width) / 32);
++      y_meta_scanline = GST_ROUND_UP_16 (GST_ROUND_UP_8 (height) / 8);
++      uv_meta_stride = GST_ROUND_UP_64 (
++          GST_ROUND_UP_16 (GST_ROUND_UP_2 (width) / 2) / 16);
++      uv_meta_scanline = GST_ROUND_UP_16 (
++          GST_ROUND_UP_8 (GST_ROUND_UP_2 (height) / 2) / 8);
++
++      y_plane_size = GST_ROUND_UP_N (y_plane_stride * y_plane_scanline, 4096);
++      uv_plane_size = GST_ROUND_UP_N (uv_plane_stride * uv_plane_scanline, 4096);
++
++      y_meta_size = GST_ROUND_UP_N (y_meta_stride * y_meta_scanline, 4096);
++      uv_meta_size = GST_ROUND_UP_N (uv_meta_stride * uv_meta_scanline, 4096);
++
++      info->stride[0] = y_plane_stride;
++      info->stride[1] = uv_plane_stride;
++      info->offset[0] = 0;
++      info->offset[1] = y_plane_size + y_meta_size;
++      info->size = info->offset[1] + uv_plane_size + uv_meta_size;
++      break;
++    }
+     case GST_VIDEO_FORMAT_ENCODED:
+     case GST_VIDEO_FORMAT_DMA_DRM:
+       break;
+diff --git a/gst-libs/gst/video/video-scaler.c b/gst-libs/gst/video/video-scaler.c
+index 5fe6bcc..2c4d0e9 100644
+--- a/gst-libs/gst/video/video-scaler.c
++++ b/gst-libs/gst/video/video-scaler.c
+@@ -1262,6 +1262,7 @@ get_functions (GstVideoScaler * hscale, GstVideoScaler * vscale,
+     case GST_VIDEO_FORMAT_NV21:
+     case GST_VIDEO_FORMAT_NV24:
+     case GST_VIDEO_FORMAT_NV61:
++    case GST_VIDEO_FORMAT_NV12_Q08C:
+       *bits = 8;
+       *n_elems = 2;
+       break;
+diff --git a/tests/check/libs/video.c b/tests/check/libs/video.c
+index aac6982..d727524 100644
+--- a/tests/check/libs/video.c
++++ b/tests/check/libs/video.c
+@@ -2185,6 +2185,9 @@ GST_START_TEST (test_video_pack_unpack2)
+     if (format == GST_VIDEO_FORMAT_DMA_DRM)
+       continue;
+ 
++    if (format == GST_VIDEO_FORMAT_NV12_Q08C)
++      continue;
++
+     finfo = gst_video_format_get_info (format);
+     fail_unless (finfo != NULL);
+ 
+@@ -3292,6 +3295,7 @@ GST_START_TEST (test_video_formats_pstrides)
+         || fmt == GST_VIDEO_FORMAT_NV12_8L128
+         || fmt == GST_VIDEO_FORMAT_NV12_10BE_8L128
+         || fmt == GST_VIDEO_FORMAT_NV12_10LE40_4L4
++        || fmt == GST_VIDEO_FORMAT_NV12_Q08C
+         || fmt == GST_VIDEO_FORMAT_DMA_DRM
+         || fmt == GST_VIDEO_FORMAT_MT2110T || fmt == GST_VIDEO_FORMAT_MT2110R) {
+       fmt++;
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-base/0002-video-Add-support-for-NV12_Q10LE32C-compressed-10-bi.patch
+++ b/gstreamer1.0-plugins-base/0002-video-Add-support-for-NV12_Q10LE32C-compressed-10-bi.patch
@@ -1,0 +1,168 @@
+From 93ba7c4f5c622dd78d1f9d3c2308a945d12da133 Mon Sep 17 00:00:00 2001
+From: Hui Liu <huliu@qti.qualcomm.com>
+Date: Thu, 29 Jan 2026 13:17:11 +0530
+Subject: [PATCH 2/3] video: Add support for NV12_Q10LE32C (compressed 10-bit)
+
+Upstream-Status: Denied [Same reason as 8-bit compressed format, https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9712]
+
+Signed-off-by: Bala Sai Kosuri <bkosuri@qti.qualcomm.com>
+---
+ gst-libs/gst/video/video-format.c | 23 +++++++++++++++++++++
+ gst-libs/gst/video/video-format.h | 10 ++++++++-
+ gst-libs/gst/video/video-info.c   | 34 +++++++++++++++++++++++++++++++
+ tests/check/libs/video.c          |  4 ++++
+ 4 files changed, 70 insertions(+), 1 deletion(-)
+
+diff --git a/gst-libs/gst/video/video-format.c b/gst-libs/gst/video/video-format.c
+index d731997..e305076 100644
+--- a/gst-libs/gst/video/video-format.c
++++ b/gst-libs/gst/video/video-format.c
+@@ -1741,6 +1741,24 @@ pack_NV12_Q08C (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
+   GST_FIXME ("Pack NV12_Q08C is not yet supported.");
+ }
+ 
++#define PACK_NV12_Q10LE32C GST_VIDEO_FORMAT_NV12_10LE32, unpack_NV12_Q10LE32C, 1, pack_NV12_Q10LE32C
++static void
++unpack_NV12_Q10LE32C (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
++    gpointer dest, const gpointer data[GST_VIDEO_MAX_PLANES],
++    const gint stride[GST_VIDEO_MAX_PLANES], gint x, gint y, gint width)
++{
++  GST_FIXME ("Unpack NV12_Q10LE32C is not yet supported.");
++}
++
++static void
++pack_NV12_Q10LE32C (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
++    const gpointer src, gint sstride, gpointer data[GST_VIDEO_MAX_PLANES],
++    const gint stride[GST_VIDEO_MAX_PLANES], GstVideoChromaSite chroma_site,
++    gint y, gint width)
++{
++  GST_FIXME ("Pack NV12_Q10LE32C is not yet supported.");
++}
++
+ #define PACK_AV12 GST_VIDEO_FORMAT_AYUV, unpack_AV12, 1, pack_AV12
+ static void
+ unpack_AV12 (const GstVideoFormatInfo * info, GstVideoPackFlags flags,
+@@ -8290,6 +8308,9 @@ static const VideoFormat formats[] = {
+   MAKE_YUV_FORMAT (NV12_Q08C, "raw video",
+       GST_MAKE_FOURCC ('Q', '0', '8', 'C'), DPTH888, PSTR122, PLANE011,
+       OFFS001, SUB420, PACK_NV12_Q08C),
++  MAKE_YUV_FORMAT (NV12_Q10LE32C, "raw video",
++      GST_MAKE_FOURCC ('Q', '1', '0', 'C'), DPTH10_10_10, PSTR0, PLANE011,
++      OFFS001, SUB420, PACK_NV12_Q10LE32C),
+ };
+ 
+ G_GNUC_END_IGNORE_DEPRECATIONS;
+@@ -8552,6 +8573,8 @@ gst_video_format_from_fourcc (guint32 fourcc)
+       return GST_VIDEO_FORMAT_BGR10A2_LE;
+     case GST_MAKE_FOURCC ('Q', '0', '8', 'C'):
+       return GST_VIDEO_FORMAT_NV12_Q08C;
++    case GST_MAKE_FOURCC ('Q', '1', '0', 'C'):
++      return GST_VIDEO_FORMAT_NV12_Q10LE32C;
+ 
+     default:
+       return GST_VIDEO_FORMAT_UNKNOWN;
+diff --git a/gst-libs/gst/video/video-format.h b/gst-libs/gst/video/video-format.h
+index ed64d98..98789f0 100644
+--- a/gst-libs/gst/video/video-format.h
++++ b/gst-libs/gst/video/video-format.h
+@@ -178,6 +178,7 @@ G_BEGIN_DECLS
+  * @GST_VIDEO_FORMAT_BGR10x2_LE: packed 4:4:4 RGB (B-G-R-x), 10 bits for R/G/B channel and MSB 2 bits for padding (Since: 1.28)
+  * @GST_VIDEO_FORMAT_RGB10x2_LE: packed 4:4:4 RGB (R-G-B-x), 10 bits for R/G/B channel and MSB 2 bits for padding (Since: 1.28)
+  * @GST_VIDEO_FORMAT_NV12_Q08C: Qualcomm NV12 8bit compressed format
++ * @GST_VIDEO_FORMAT_NV12_Q10LE32C: Qualcomm NV12 10bit compressed format
+  *
+  * Enum value describing the most common video formats.
+  *
+@@ -709,6 +710,13 @@ typedef enum {
+    */
+   GST_VIDEO_FORMAT_NV12_Q08C,
+ 
++  /**
++   * GST_VIDEO_FORMAT_NV12_Q10LE32C:
++   *
++   * Qualcomm NV12 10-bit compressed format.
++   */
++  GST_VIDEO_FORMAT_NV12_Q10LE32C,
++
+   /* Update GST_VIDEO_FORMAT_LAST below when adding more formats here */
+ } GstVideoFormat;
+ 
+@@ -719,7 +727,7 @@ typedef enum {
+  *
+  * Since: 1.26
+  */
+-#define GST_VIDEO_FORMAT_LAST (GST_VIDEO_FORMAT_NV12_Q08C + 1)
++#define GST_VIDEO_FORMAT_LAST (GST_VIDEO_FORMAT_NV12_Q10LE32C + 1)
+ 
+ #define GST_VIDEO_MAX_PLANES 4
+ #define GST_VIDEO_MAX_COMPONENTS 4
+diff --git a/gst-libs/gst/video/video-info.c b/gst-libs/gst/video/video-info.c
+index 0c982d6..83c2845 100644
+--- a/gst-libs/gst/video/video-info.c
++++ b/gst-libs/gst/video/video-info.c
+@@ -1430,6 +1430,40 @@ fill_planes (GstVideoInfo * info, gsize plane_size[GST_VIDEO_MAX_PLANES])
+       info->size = info->offset[1] + uv_plane_size + uv_meta_size;
+       break;
+     }
++    case GST_VIDEO_FORMAT_NV12_Q10LE32C:
++    {
++      gint y_plane_stride = 0, y_meta_stride = 0, y_meta_scanline = 0;
++      gint uv_plane_stride = 0, uv_meta_stride = 0, uv_meta_scanline = 0;
++      gint y_plane_scanline = 0, y_plane_size = 0, y_meta_size = 0;
++      gint uv_plane_scanline = 0, uv_plane_size = 0, uv_meta_size = 0;
++
++      y_plane_stride = GST_ROUND_UP_N (
++          (GST_ROUND_UP_N (width, 192) * 4 / 3), 256);
++      y_plane_scanline = GST_ROUND_UP_16 (height);
++      uv_plane_stride = GST_ROUND_UP_N (
++          (GST_ROUND_UP_N (width, 192) * 4 / 3), 256);
++      uv_plane_scanline = GST_ROUND_UP_16 (GST_ROUND_UP_2 (height) / 2);
++
++      y_meta_stride = GST_ROUND_UP_64 (GST_ROUND_UP_N (width, 48) / 48);
++      y_meta_scanline = GST_ROUND_UP_16 (GST_ROUND_UP_4 (height) / 4);
++      uv_meta_stride = GST_ROUND_UP_64 (
++          GST_ROUND_UP_N ((GST_ROUND_UP_2 (width) / 2), 24) / 24);
++      uv_meta_scanline = GST_ROUND_UP_16 (
++          GST_ROUND_UP_4 (GST_ROUND_UP_2 (height) / 2) / 4);
++
++      y_plane_size = GST_ROUND_UP_N (y_plane_stride * y_plane_scanline, 4096);
++      uv_plane_size = GST_ROUND_UP_N (uv_plane_stride * uv_plane_scanline, 4096);
++
++      y_meta_size = GST_ROUND_UP_N (y_meta_stride * y_meta_scanline, 4096);
++      uv_meta_size = GST_ROUND_UP_N (uv_meta_stride * uv_meta_scanline, 4096);
++
++      info->stride[0] = y_plane_stride;
++      info->stride[1] = uv_plane_stride;
++      info->offset[0] = 0;
++      info->offset[1] = y_plane_size + y_meta_size;
++      info->size = info->offset[1] + uv_plane_size + uv_meta_size;
++      break;
++    }
+     case GST_VIDEO_FORMAT_ENCODED:
+     case GST_VIDEO_FORMAT_DMA_DRM:
+       break;
+diff --git a/tests/check/libs/video.c b/tests/check/libs/video.c
+index d727524..9b0b243 100644
+--- a/tests/check/libs/video.c
++++ b/tests/check/libs/video.c
+@@ -2188,6 +2188,9 @@ GST_START_TEST (test_video_pack_unpack2)
+     if (format == GST_VIDEO_FORMAT_NV12_Q08C)
+       continue;
+ 
++    if (format == GST_VIDEO_FORMAT_NV12_Q10LE32C)
++      continue;
++
+     finfo = gst_video_format_get_info (format);
+     fail_unless (finfo != NULL);
+ 
+@@ -3296,6 +3299,7 @@ GST_START_TEST (test_video_formats_pstrides)
+         || fmt == GST_VIDEO_FORMAT_NV12_10BE_8L128
+         || fmt == GST_VIDEO_FORMAT_NV12_10LE40_4L4
+         || fmt == GST_VIDEO_FORMAT_NV12_Q08C
++        || fmt == GST_VIDEO_FORMAT_NV12_Q10LE32C
+         || fmt == GST_VIDEO_FORMAT_DMA_DRM
+         || fmt == GST_VIDEO_FORMAT_MT2110T || fmt == GST_VIDEO_FORMAT_MT2110R) {
+       fmt++;
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-base/0003-videometa-Update-the-aggregation-logic-for-stride-al.patch
+++ b/gstreamer1.0-plugins-base/0003-videometa-Update-the-aggregation-logic-for-stride-al.patch
@@ -1,0 +1,52 @@
+From 8a3e564be0badc5acac10c19cf904efdd07c2b2e Mon Sep 17 00:00:00 2001
+From: Raja Ganapathi Busam <quic_rbusam@quicinc.com>
+Date: Thu, 13 Mar 2025 22:11:35 +0530
+Subject: [PATCH 3/3] videometa: Update the aggregation logic for stride align
+
+- Stride aligns can be of any number
+- Current aggregation logic for stride align will work only
+  when the stride aligns are power of 2
+- Taking least common multiple of the stride aligns to aggregate
+
+Upstream-Status: Denied [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10195]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ gst-libs/gst/video/gstvideometa.c | 21 ++++++++++++++++++---
+ 1 file changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/gst-libs/gst/video/gstvideometa.c b/gst-libs/gst/video/gstvideometa.c
+index 9319663..e913e11 100644
+--- a/gst-libs/gst/video/gstvideometa.c
++++ b/gst-libs/gst/video/gstvideometa.c
+@@ -174,9 +174,24 @@ gst_video_meta_api_params_aggregator (GstStructure ** aggregated_params,
+   aggregated_align.padding_right =
+       MAX (align0.padding_right, align1.padding_right);
+ 
+-  for (int n = 0; n < GST_VIDEO_MAX_PLANES; ++n)
+-    aggregated_align.stride_align[n] =
+-        align0.stride_align[n] | align1.stride_align[n];
++  // Calculate the lowest common multiple for the stride alignments.
++  for (int n = 0; n < GST_VIDEO_MAX_PLANES; ++n) {
++    guint max = 0;
++
++    max = MAX (align0.stride_align[n], align1.stride_align[n]);
++    aggregated_align.stride_align[n] = max;
++
++    if ((align0.stride_align[n] == 0) || (align1.stride_align[n] == 0))
++      continue;
++
++    while (
++        ((aggregated_align.stride_align[n] + 1) % (align0.stride_align[n] + 1)
++            != 0)
++        || ((aggregated_align.stride_align[n] + 1)
++                % (align1.stride_align[n] + 1)
++            != 0))
++      aggregated_align.stride_align[n] += max + 1;
++  }
+ 
+   *aggregated_params = gst_structure_new_empty ("video-meta");
+ 
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-base/series
+++ b/gstreamer1.0-plugins-base/series
@@ -1,0 +1,3 @@
+0001-video-Add-support-for-NV12_Q08C-compressed-8-bit-for.patch
+0002-video-Add-support-for-NV12_Q10LE32C-compressed-10-bi.patch
+0003-videometa-Update-the-aggregation-logic-for-stride-al.patch


### PR DESCRIPTION
- video: Added support for NV12_Q08C (compressed 8-bit) format
- video: Added support for NV12_Q10LE32C (compressed 10-bit) format
- videometa: Update the aggregation logic for stride align
- Added series file to apply patches in series using quilt tool