### PR TITLE
gstreamer1.0-plugins-bad: Add patch files for version 1.28.0

### DIFF
--- a/gstreamer1.0-plugins-bad/0001-wayland-Add-support-for-NV12_Q08C-compressed-8-bit.patch
+++ b/gstreamer1.0-plugins-bad/0001-wayland-Add-support-for-NV12_Q08C-compressed-8-bit.patch
@@ -1,0 +1,120 @@
+From 96813b1561d0d5824f966e6cef044818e2062280 Mon Sep 17 00:00:00 2001
+From: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+Date: Thu, 29 Jan 2026 14:43:26 +0530
+Subject: [PATCH 1/3] wayland: Add support for NV12_Q08C (compressed 8-bit)
+
+- Add NV12_Q08C to static caps
+- Update the modifier value in set_caps for NV12_Q08C
+- Add NV12_Q08C to shm formats if present in dmabuf formats
+
+Upstream-Status: Denied [Adding NV12_Q08C format is denied by upstream, for compatibility, need to maintain this patch. https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9712 ]
+
+Signed-off-by: Bala Sai Kosuri <bkosuri@qti.qualcomm.com>
+---
+ ext/wayland/gstwaylandsink.c            | 34 +++++++++++++++++++++++++
+ gst-libs/gst/wayland/gstwlvideoformat.c |  5 ++++
+ gst-libs/gst/wayland/gstwlvideoformat.h |  4 +--
+ 3 files changed, 41 insertions(+), 2 deletions(-)
+
+diff --git a/ext/wayland/gstwaylandsink.c b/ext/wayland/gstwaylandsink.c
+index 08de8d7..8b8aba9 100644
+--- a/ext/wayland/gstwaylandsink.c
++++ b/ext/wayland/gstwaylandsink.c
+@@ -651,11 +651,30 @@ gst_wayland_sink_get_caps (GstBaseSink * bsink, GstCaps * filter)
+ 
+   if (self->display) {
+     GValue format_list = G_VALUE_INIT;
++    GValue value = G_VALUE_INIT;
++    gint j;
+ 
+     g_value_init (&format_list, GST_TYPE_LIST);
+ 
+     /* Add corresponding dmabuf formats */
+     gst_wl_display_fill_dmabuf_format_list (self->display, &format_list);
++
++    for (j = 0; j < gst_value_list_get_size (&format_list); j++) {
++      const GValue *vlist = gst_value_list_get_value (&format_list, j);
++      guint32 fourcc;
++      guint64 modifier;
++
++      fourcc = gst_video_dma_drm_fourcc_from_string (g_value_get_string (vlist),
++          &modifier);
++      if (fourcc == DRM_FORMAT_NV12 &&
++          modifier == DRM_FORMAT_MOD_QCOM_COMPRESSED) {
++        GST_DEBUG_OBJECT (self, "Found NV12_Q08C in DMAbuf format list");
++        g_value_init (&value, G_TYPE_STRING);
++        g_value_set_static_string (&value,
++            gst_video_format_to_string (GST_VIDEO_FORMAT_NV12_Q08C));
++      }
++    }
++
+     gst_structure_take_value (gst_caps_get_structure (caps, 0), "drm-format",
+         &format_list);
+ 
+@@ -663,6 +682,10 @@ gst_wayland_sink_get_caps (GstBaseSink * bsink, GstCaps * filter)
+ 
+     /* Add corresponding shm formats */
+     gst_wl_display_fill_shm_format_list (self->display, &format_list);
++    if (G_VALUE_HOLDS_STRING (&value)) {
++      GST_DEBUG_OBJECT (self, "Adding NV12_Q08C to SHM format list");
++      gst_value_list_append_and_take_value (&format_list, &value);
++    }
+     gst_structure_take_value (gst_caps_get_structure (caps, 1), "format",
+         &format_list);
+ 
+@@ -789,6 +812,17 @@ gst_wayland_sink_set_caps (GstBaseSink * bsink, GstCaps * caps)
+     if (!gst_video_info_dma_drm_from_video_info (&self->drm_info,
+             &self->render_info, DRM_FORMAT_MOD_LINEAR))
+       gst_video_info_dma_drm_init (&self->drm_info);
++
++    if (GST_VIDEO_INFO_FORMAT (&self->video_info) == GST_VIDEO_FORMAT_NV12_Q08C) {
++      self->drm_info.vinfo = self->render_info;
++      self->drm_info.drm_fourcc = gst_video_dma_drm_fourcc_from_format (
++          GST_VIDEO_FORMAT_NV12);
++      self->drm_info.drm_modifier = DRM_FORMAT_MOD_QCOM_COMPRESSED;
++
++      GST_DEBUG_OBJECT (self, "DRM format %" GST_FOURCC_FORMAT " Modifier "
++          "0x%016" G_GINT64_MODIFIER "x", GST_FOURCC_ARGS (
++              self->drm_info.drm_fourcc), self->drm_info.drm_modifier);
++    }
+   }
+ 
+   self->have_mastering_info =
+diff --git a/gst-libs/gst/wayland/gstwlvideoformat.c b/gst-libs/gst/wayland/gstwlvideoformat.c
+index b4c87cd..9a25098 100644
+--- a/gst-libs/gst/wayland/gstwlvideoformat.c
++++ b/gst-libs/gst/wayland/gstwlvideoformat.c
+@@ -53,6 +53,11 @@ gst_video_format_to_wl_shm_format (GstVideoFormat format)
+ 
+   drm_format = gst_video_dma_drm_format_from_gst_format (format, &modifier);
+ 
++  // Since modifier for NV12_Q08C is not linear, this is required to bypass shm format check.
++  // caps negotiation passes only when a format is supported in shm interface.
++  if (format == GST_VIDEO_FORMAT_NV12_Q08C)
++    return drm_format;
++
+   if (drm_format == DRM_FORMAT_INVALID || modifier != DRM_FORMAT_MOD_LINEAR) {
+     GST_WARNING ("wayland shm video format not found");
+     return -1;
+diff --git a/gst-libs/gst/wayland/gstwlvideoformat.h b/gst-libs/gst/wayland/gstwlvideoformat.h
+index 53b579f..884968a 100644
+--- a/gst-libs/gst/wayland/gstwlvideoformat.h
++++ b/gst-libs/gst/wayland/gstwlvideoformat.h
+@@ -40,12 +40,12 @@ G_BEGIN_DECLS
+ #define GST_WL_VIDEO_FORMATS "{ BGR10A2_LE, RGB10A2_LE, AYUV, RGBA, ARGB, " \
+     "BGRA, ABGR, BGR10x2_LE, RGB10x2_LE, P010_10LE, NV12_10LE40, Y444, v308, " \
+     "RGBx, xRGB, BGRx, xBGR, RGB, BGR, Y42B, NV16, NV61, YUY2, YVYU, UYVY, " \
+-    "I420, YV12, NV12, NV21, Y41B, YUV9, YVU9, BGR16, RGB16 }"
++    "I420, YV12, NV12, NV21, Y41B, YUV9, YVU9, BGR16, RGB16, NV12_Q08C }"
+ #elif G_BYTE_ORDER == G_LITTLE_ENDIAN
+ #define GST_WL_VIDEO_FORMATS "{ BGR10A2_LE, RGB10A2_LE, AYUV, RGBA, ARGB, " \
+     "BGRA, ABGR, BGR10x2_LE, RGB10x2_LE, P010_10LE, NV12_10LE40, Y444, v308, " \
+     "RGBx, xRGB, BGRx, xBGR, RGB, BGR, Y42B, NV16, NV61, YUY2, YVYU, UYVY, " \
+-    "I420, YV12, NV12, NV21, Y41B, YUV9, YVU9, BGR16, RGB16 }"
++    "I420, YV12, NV12, NV21, Y41B, YUV9, YVU9, BGR16, RGB16, NV12_Q08C }"
+ #endif
+ 
+ GST_WL_API
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-bad/0002-waylandsink-Release-pending-buffers-during-PAUSED-to.patch
+++ b/gstreamer1.0-plugins-bad/0002-waylandsink-Release-pending-buffers-during-PAUSED-to.patch
@@ -1,0 +1,72 @@
+From 862b98a61914f56236eaa1c60ba135642f239277 Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Thu, 29 Jan 2026 14:50:36 +0530
+Subject: [PATCH 2/3] waylandsink: Release pending buffers during PAUSED to
+ READY state change
+
+Add functionality to forcibly release any pending buffers in the
+wayland compositor at GST_STATE_CHANGE_PAUSED_TO_READY. This is
+needed because some live sources may require all buffers to be
+returned when transitioning to READY state.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10386]
+
+Signed-off-by: Bala Sai Kosuri <bkosuri@qti.qualcomm.com>
+---
+ ext/wayland/gstwaylandsink.c        |  1 +
+ gst-libs/gst/wayland/gstwldisplay.c | 16 ++++++++++++++++
+ gst-libs/gst/wayland/gstwldisplay.h |  3 +++
+ 3 files changed, 20 insertions(+)
+
+diff --git a/ext/wayland/gstwaylandsink.c b/ext/wayland/gstwaylandsink.c
+index 8b8aba9..946e246 100644
+--- a/ext/wayland/gstwaylandsink.c
++++ b/ext/wayland/gstwaylandsink.c
+@@ -557,6 +557,7 @@ gst_wayland_sink_change_state (GstElement * element, GstStateChange transition)
+         }
+       }
+ 
++      gst_wl_display_force_release_buffers (self->display);
+       break;
+     case GST_STATE_CHANGE_READY_TO_NULL:
+       g_mutex_lock (&self->display_lock);
+diff --git a/gst-libs/gst/wayland/gstwldisplay.c b/gst-libs/gst/wayland/gstwldisplay.c
+index a12813e..797b397 100644
+--- a/gst-libs/gst/wayland/gstwldisplay.c
++++ b/gst-libs/gst/wayland/gstwldisplay.c
+@@ -1236,3 +1236,19 @@ gst_wl_display_get_output_by_name (GstWlDisplay * self,
+ 
+   return output;
+ }
++
++void
++gst_wl_display_force_release_buffers (GstWlDisplay * self)
++{
++  GstWlDisplayPrivate *priv = gst_wl_display_get_instance_private (self);
++
++  /* to avoid buffers being unregistered from another thread
++   * at the same time, take their ownership */
++  g_mutex_lock (&priv->buffers_mutex);
++  g_hash_table_foreach (priv->buffers, gst_wl_ref_wl_buffer, NULL);
++  g_mutex_unlock (&priv->buffers_mutex);
++
++  g_hash_table_foreach (priv->buffers,
++      (GHFunc) gst_wl_buffer_force_release_and_unref, NULL);
++  g_hash_table_remove_all (priv->buffers);
++}
+\ No newline at end of file
+diff --git a/gst-libs/gst/wayland/gstwldisplay.h b/gst-libs/gst/wayland/gstwldisplay.h
+index ca6e6a9..8d9f669 100644
+--- a/gst-libs/gst/wayland/gstwldisplay.h
++++ b/gst-libs/gst/wayland/gstwldisplay.h
+@@ -148,4 +148,7 @@ gboolean gst_wl_display_are_color_coefficients_supported (GstWlDisplay * self, u
+ GST_WL_API
+ GstWlOutput * gst_wl_display_get_output_by_name (GstWlDisplay * self, const gchar * output_name);
+ 
++GST_WL_API
++void gst_wl_display_force_release_buffers (GstWlDisplay * self);
++
+ G_END_DECLS
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-bad/0003-waylandsink-support-gap-buffers.patch
+++ b/gstreamer1.0-plugins-bad/0003-waylandsink-support-gap-buffers.patch
@@ -1,0 +1,35 @@
+From f05ef5545e0f7cc38af1797f0873bde21adbc591 Mon Sep 17 00:00:00 2001
+From: "Petar G. Georgiev" <quic_petarg@quicinc.com>
+Date: Thu, 18 May 2023 11:38:14 +0300
+Subject: [PATCH 3/3] waylandsink: support gap buffers
+
+- When a GAP buffer is received for rendering, simply drop it.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10275 ]
+
+Signed-off-by: Petar G. Georgiev <quic_petarg@quicinc.com>
+---
+ ext/wayland/gstwaylandsink.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/ext/wayland/gstwaylandsink.c b/ext/wayland/gstwaylandsink.c
+index 946e246..7cd2b54 100644
+--- a/ext/wayland/gstwaylandsink.c
++++ b/ext/wayland/gstwaylandsink.c
+@@ -1097,6 +1097,13 @@ gst_wayland_sink_show_frame (GstVideoSink * vsink, GstBuffer * buffer)
+     }
+   }
+ 
++  /* GAP buffer, nothing further to do */
++  if (gst_buffer_get_size (buffer) == 0 &&
++      GST_BUFFER_FLAG_IS_SET (buffer, GST_BUFFER_FLAG_GAP)) {
++    GST_LOG_OBJECT (self, "buffer %p dropped (gap in the stream)", buffer);
++    goto done;
++  }
++
+   /* make sure that the application has called set_render_rectangle() */
+   if (G_UNLIKELY (gst_wl_window_get_render_rectangle (self->window)->w == 0))
+     goto no_window_size;
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-bad/series
+++ b/gstreamer1.0-plugins-bad/series
@@ -1,0 +1,3 @@
+0001-wayland-Add-support-for-NV12_Q08C-compressed-8-bit.patch
+0002-waylandsink-Release-pending-buffers-during-PAUSED-to.patch
+0003-waylandsink-support-gap-buffers.patch


### PR DESCRIPTION
- wayland: Add support for NV12_Q08C (compressed 8-bit)
- waylandsink: Release pending buffers during PAUSED to READY state change
- waylandsink: support gap buffers
- Added series file to apply patches in series using quilt tool