### PR TITLE
gstreamer1.0-plugins-good: Add patch files for version 1.26.2

### DIFF
--- a/gstreamer1.0-plugins-good/0001-v4l2-Add-support-for-V4L2_PIX_FMT_QC08C-format.patch
+++ b/gstreamer1.0-plugins-good/0001-v4l2-Add-support-for-V4L2_PIX_FMT_QC08C-format.patch
@@ -1,0 +1,40 @@
+From 561c169dd99bf4a73b77af9869dd6b06070585ac Mon Sep 17 00:00:00 2001
+From: Arindam Biswas <arinbisw@qti.qualcomm.com>
+Date: Fri, 14 Feb 2025 17:30:19 +0530
+Subject: [PATCH 01/18] v4l2: Add support for V4L2_PIX_FMT_QC08C format
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+
+Signed-off-by: Arindam Biswas <arinbisw@qti.qualcomm.com>
+---
+ sys/v4l2/ext/videodev2.h | 1 +
+ sys/v4l2/gstv4l2object.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/sys/v4l2/ext/videodev2.h b/sys/v4l2/ext/videodev2.h
+index 2ceb1ca..e3b4ab3 100644
+--- a/sys/v4l2/ext/videodev2.h
++++ b/sys/v4l2/ext/videodev2.h
+@@ -775,6 +775,7 @@ struct v4l2_pix_format {
+ #define V4L2_PIX_FMT_QC08C    v4l2_fourcc('Q', '0', '8', 'C') /* Qualcomm 8-bit compressed */
+ #define V4L2_PIX_FMT_QC10C    v4l2_fourcc('Q', '1', '0', 'C') /* Qualcomm 10-bit compressed */
+ #define V4L2_PIX_FMT_AJPG     v4l2_fourcc('A', 'J', 'P', 'G') /* Aspeed JPEG */
++#define V4L2_PIX_FMT_QC08C    v4l2_fourcc('Q', '0', '8', 'C') /* Qualcomm 8-bit compressed */
+ 
+ /* 10bit raw packed, 32 bytes for every 25 pixels, last LSB 6 bits unused */
+ #define V4L2_PIX_FMT_IPU3_SBGGR10	v4l2_fourcc('i', 'p', '3', 'b') /* IPU3 packed 10-bit BGGR bayer */
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index 80189d2..5bafc64 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -191,6 +191,7 @@ static GstV4L2FormatDesc gst_v4l2_formats[] = {
+   {MAP_FMT (NV24, NV24),                        KNOWN_DRM_MAP,                      GST_V4L2_RAW},
+   {MAP_FMT (NV42, UNKNOWN),                     MAP_DRM (NV42, LINEAR),             GST_V4L2_RAW},
+   {MAP_FMT (MM21, NV12_16L32S),                 KNOWN_DRM_MAP,                      GST_V4L2_RAW},
++  {MAP_FMT (QC08C, NV12_Q08C),                  KNOWN_DRM_MAP,                      GST_V4L2_RAW},
+   {MAP_FMT (P010, P010_10LE),                   KNOWN_DRM_MAP,                      GST_V4L2_RAW},
+ 
+   /* Bayer formats - see http://www.siliconimaging.com/RGB%20Bayer.htm */
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0002-v4l2-Check-for-V4L2_BUF_FLAG_LAST-flag-to-handle-EOS.patch
+++ b/gstreamer1.0-plugins-good/0002-v4l2-Check-for-V4L2_BUF_FLAG_LAST-flag-to-handle-EOS.patch
@@ -1,0 +1,48 @@
+From 9c1416d25c373ef02b1b2c28f6106703d662984b Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Mon, 6 Jan 2025 17:32:21 +0530
+Subject: [PATCH 02/18] v4l2: Check for V4L2_BUF_FLAG_LAST flag to handle EOS
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+
+Signed-off-by: Pratik Pachange <ppachang@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2allocator.c | 15 ++++++++++++---
+ 1 file changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/sys/v4l2/gstv4l2allocator.c b/sys/v4l2/gstv4l2allocator.c
+index b64a932..91224da 100644
+--- a/sys/v4l2/gstv4l2allocator.c
++++ b/sys/v4l2/gstv4l2allocator.c
+@@ -1329,6 +1329,18 @@ gst_v4l2_allocator_dqbuf (GstV4l2Allocator * allocator,
+   if (obj->ioctl (obj->video_fd, VIDIOC_DQBUF, &buffer) < 0)
+     goto error;
+ 
++  GST_LOG_OBJECT (allocator, "dequeued buffer %i (flags 0x%X)", buffer.index,
++      buffer.flags);
++
++  /* TODO: Temporary change to handle EOS. Default implementation to check for
++   * EOS is with driver returning EPIPE error on dqbuf after last 0 bytesize
++   * buffer is dequeued. But the video driver is not signalling the poll after
++   * last buffer is dequeued. This is causing the client to wait infinetly.
++   * So check for v4l2 last buffer flag on EOS buffer.
++   */
++  if (buffer.flags & V4L2_BUF_FLAG_LAST)
++    return GST_V4L2_FLOW_LAST_BUFFER;
++
+   group = allocator->groups[buffer.index];
+ 
+   if (!IS_QUEUED (group->buffer)) {
+@@ -1339,9 +1351,6 @@ gst_v4l2_allocator_dqbuf (GstV4l2Allocator * allocator,
+ 
+   group->buffer = buffer;
+ 
+-  GST_LOG_OBJECT (allocator, "dequeued buffer %i (flags 0x%X)", buffer.index,
+-      buffer.flags);
+-
+   if (IS_QUEUED (group->buffer)) {
+     GST_DEBUG_OBJECT (allocator,
+         "driver pretends buffer is queued even if dequeue succeeded");
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0003-v4l2-Set-pixel-format-to-HEVC-for-H265-MIME-type.patch
+++ b/gstreamer1.0-plugins-good/0003-v4l2-Set-pixel-format-to-HEVC-for-H265-MIME-type.patch
@@ -1,0 +1,64 @@
+From 42f98ec8d5a23521966645392b57f02ea89b8945 Mon Sep 17 00:00:00 2001
+From: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+Date: Thu, 16 Jan 2025 14:44:44 +0530
+Subject: [PATCH 03/18] v4l2: Set pixel format to HEVC for H265 MIME type
+
+- By default, video driver operates on H264 codec format.
+- As per video driver's expectation, pixelformat has to be set first on
+  CAPTURE port first and then OUTPUT port.
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2videoenc.c | 34 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 34 insertions(+)
+
+diff --git a/sys/v4l2/gstv4l2videoenc.c b/sys/v4l2/gstv4l2videoenc.c
+index 1cf09da..5cd027b 100644
+--- a/sys/v4l2/gstv4l2videoenc.c
++++ b/sys/v4l2/gstv4l2videoenc.c
+@@ -357,6 +357,40 @@ gst_v4l2_video_enc_set_format (GstVideoEncoder * encoder,
+   output = gst_video_encoder_set_output_state (encoder, outcaps, state);
+   gst_video_codec_state_unref (output);
+ 
++  {
++    GstV4l2Object *v4l2object = GST_V4L2_OBJECT (self->v4l2capture);
++    struct v4l2_format format;
++    GstStructure *s;
++    const gchar *mimetype;
++
++    s = gst_caps_get_structure(outcaps, 0);
++    mimetype = gst_structure_get_name (s);
++
++    if (g_str_equal (mimetype, "video/x-h265")) {
++      memset (&format, 0x00, sizeof (struct v4l2_format));
++      format.type = v4l2object->type;
++      if (v4l2object->ioctl (v4l2object->video_fd, VIDIOC_G_FMT, &format) < 0) {
++        GST_ERROR_OBJECT (self, "Failed to call VIDIOC_G_FMT with error %s",
++            g_strerror (errno));
++        return FALSE;
++      }
++      GST_DEBUG_OBJECT (self, "Initial pixel format returned by VIDIOC_G_FMT: %"
++          GST_FOURCC_FORMAT, GST_FOURCC_ARGS (format.fmt.pix.pixelformat));
++
++      // Overriding the pixel format with H265
++      format.fmt.pix.pixelformat = V4L2_PIX_FMT_HEVC;
++      if (v4l2object->ioctl (v4l2object->video_fd, VIDIOC_S_FMT, &format) < 0) {
++        GST_ERROR_OBJECT (self, "Failed to call VIDIOC_S_FMT for format %"
++            GST_FOURCC_FORMAT " with error %s",
++            GST_FOURCC_ARGS (format.fmt.pix.pixelformat),
++            g_strerror (errno));
++        return FALSE;
++      }
++      GST_DEBUG_OBJECT (self, "Pixel format set to %" GST_FOURCC_FORMAT,
++          GST_FOURCC_ARGS (format.fmt.pix.pixelformat));
++    }
++  }
++
+   if (!gst_video_encoder_negotiate (encoder))
+     return FALSE;
+ 
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0004-v4l2-Add-support-for-fd-memory-import.patch
+++ b/gstreamer1.0-plugins-good/0004-v4l2-Add-support-for-fd-memory-import.patch
@@ -1,0 +1,68 @@
+From a76a6d26988bba2ac5cf9ae5bdaef5594f231df4 Mon Sep 17 00:00:00 2001
+From: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+Date: Mon, 27 Jan 2025 21:04:32 +0530
+Subject: [PATCH 04/18] v4l2: Add support for fd memory import
+
+Camera provides FD memory instead of DMA memory for performance reasons.
+Though, FD is allocated using DMA heap.
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2allocator.c  | 7 +++++--
+ sys/v4l2/gstv4l2bufferpool.c | 2 +-
+ sys/v4l2/gstv4l2object.c     | 2 +-
+ 3 files changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/sys/v4l2/gstv4l2allocator.c b/sys/v4l2/gstv4l2allocator.c
+index 91224da..4176f9e 100644
+--- a/sys/v4l2/gstv4l2allocator.c
++++ b/sys/v4l2/gstv4l2allocator.c
+@@ -1112,12 +1112,15 @@ gst_v4l2_allocator_import_dmabuf (GstV4l2Allocator * allocator,
+     gint dmafd;
+     gsize size, offset, maxsize;
+ 
+-    if (!gst_is_dmabuf_memory (dma_mem[i]))
++    if (!gst_is_dmabuf_memory (dma_mem[i]) && !gst_is_fd_memory(dma_mem[i]))
+       goto not_dmabuf;
+ 
+     size = gst_memory_get_sizes (dma_mem[i], &offset, &maxsize);
+ 
+-    dmafd = gst_dmabuf_memory_get_fd (dma_mem[i]);
++    if (gst_is_dmabuf_memory (dma_mem[i]))
++      dmafd = gst_dmabuf_memory_get_fd (dma_mem[i]);
++    else
++      dmafd = gst_fd_memory_get_fd (dma_mem[i]);
+ 
+     GST_LOG_OBJECT (allocator, "[%i] imported DMABUF as fd %i plane %d",
+         group->buffer.index, dmafd, i);
+diff --git a/sys/v4l2/gstv4l2bufferpool.c b/sys/v4l2/gstv4l2bufferpool.c
+index 4e59743..840e0f9 100644
+--- a/sys/v4l2/gstv4l2bufferpool.c
++++ b/sys/v4l2/gstv4l2bufferpool.c
+@@ -102,7 +102,7 @@ gst_v4l2_is_buffer_valid (GstBuffer * buffer, GstV4l2MemoryGroup ** out_group,
+   if (GST_BUFFER_FLAG_IS_SET (buffer, GST_BUFFER_FLAG_TAG_MEMORY))
+     goto done;
+ 
+-  if (gst_is_dmabuf_memory (mem))
++  if (gst_is_dmabuf_memory (mem) || gst_is_fd_memory (mem))
+     mem = gst_mini_object_get_qdata (GST_MINI_OBJECT (mem),
+         GST_V4L2_MEMORY_QUARK);
+ 
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index 5bafc64..6c755c3 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -6127,7 +6127,7 @@ gst_v4l2_object_try_import (GstV4l2Object * obj, GstBuffer * buffer)
+     for (i = 0; i < n_mem; i++) {
+       GstMemory *mem = gst_buffer_peek_memory (buffer, i);
+ 
+-      if (!gst_is_dmabuf_memory (mem)) {
++      if (!gst_is_dmabuf_memory (mem) && !gst_is_fd_memory (mem)) {
+         GST_DEBUG_OBJECT (obj->dbg_obj, "Cannot import non-DMABuf memory.");
+         return FALSE;
+       }
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0005-v4l2-Add-support-for-AV1-format.patch
+++ b/gstreamer1.0-plugins-good/0005-v4l2-Add-support-for-AV1-format.patch
@@ -1,0 +1,73 @@
+From 318a8cb5ce65fb9315256f9e41a62d4a6cda8eb9 Mon Sep 17 00:00:00 2001
+From: Arindam Biswas <arinbisw@qti.qualcomm.com>
+Date: Fri, 14 Feb 2025 18:06:51 +0530
+Subject: [PATCH 05/18] v4l2: Add support for AV1 format
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+
+Signed-off-by: Arindam Biswas <arinbisw@qti.qualcomm.com>
+---
+ sys/v4l2/ext/videodev2.h   | 1 +
+ sys/v4l2/gstv4l2object.c   | 6 ++++++
+ sys/v4l2/gstv4l2videodec.c | 2 ++
+ 3 files changed, 9 insertions(+)
+
+diff --git a/sys/v4l2/ext/videodev2.h b/sys/v4l2/ext/videodev2.h
+index e3b4ab3..da5e0c1 100644
+--- a/sys/v4l2/ext/videodev2.h
++++ b/sys/v4l2/ext/videodev2.h
+@@ -736,6 +736,7 @@ struct v4l2_pix_format {
+ #define V4L2_PIX_FMT_SPK      v4l2_fourcc('S', 'P', 'K', '0') /* Sorenson Spark */
+ #define V4L2_PIX_FMT_RV30     v4l2_fourcc('R', 'V', '3', '0') /* RealVideo 8 */
+ #define V4L2_PIX_FMT_RV40     v4l2_fourcc('R', 'V', '4', '0') /* RealVideo 9 & 10 */
++#define V4L2_PIX_FMT_AV1     v4l2_fourcc('A', 'V', '1', '0') /* AV1 */
+ 
+ /*  Vendor-specific formats   */
+ #define V4L2_PIX_FMT_CPIA1    v4l2_fourcc('C', 'P', 'I', 'A') /* cpia1 YUV */
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index 6c755c3..dcbe0eb 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -236,6 +236,7 @@ static GstV4L2FormatDesc gst_v4l2_formats[] = {
+   {MAP_ENC_FMT (VC1_ANNEX_L, ENCODED),  GST_V4L2_CODEC},
+   {MAP_ENC_FMT (VP8, ENCODED),          GST_V4L2_CODEC | GST_V4L2_NO_PARSE},
+   {MAP_ENC_FMT (VP9, ENCODED),          GST_V4L2_CODEC | GST_V4L2_NO_PARSE},
++  {MAP_ENC_FMT (AV1, ENCODED),          GST_V4L2_CODEC},
+ 
+   /*  Vendor-specific formats   */
+   {MAP_ENC_FMT (WNVA, ENCODED),     GST_V4L2_CODEC | GST_V4L2_RESOLUTION_AND_RATE},
+@@ -1593,6 +1594,9 @@ gst_v4l2_object_v4l2fourcc_to_bare_struct (guint32 fourcc,
+     case V4L2_PIX_FMT_VP9:
+       structure = gst_structure_new_empty ("video/x-vp9");
+       break;
++    case V4L2_PIX_FMT_AV1:
++      structure = gst_structure_new_empty ("video/x-av1");
++      break;
+     case V4L2_PIX_FMT_DV:
+       structure =
+           gst_structure_new ("video/x-dv", "systemstream", G_TYPE_BOOLEAN, TRUE,
+@@ -2042,6 +2046,8 @@ gst_v4l2_object_get_caps_info (GstV4l2Object * v4l2object, GstCaps * caps,
+     fourcc = V4L2_PIX_FMT_VP8;
+   } else if (g_str_equal (mimetype, "video/x-vp9")) {
+     fourcc = V4L2_PIX_FMT_VP9;
++  } else if (g_str_equal (mimetype, "video/x-av1")) {
++      fourcc = V4L2_PIX_FMT_AV1;
+   } else if (g_str_equal (mimetype, "video/x-bayer")) {
+     const gchar *format = gst_structure_get_string (structure, "format");
+     if (format) {
+diff --git a/sys/v4l2/gstv4l2videodec.c b/sys/v4l2/gstv4l2videodec.c
+index b7cd9ac..8fbd18b 100644
+--- a/sys/v4l2/gstv4l2videodec.c
++++ b/sys/v4l2/gstv4l2videodec.c
+@@ -1451,6 +1451,8 @@ G_STMT_START { \
+   } else if (gst_structure_has_name (s, "video/x-vp9")) {
+     SET_META ("VP9");
+     cdata->codec = gst_v4l2_vp9_get_codec ();
++  } else if (gst_structure_has_name (s, "video/x-av1")) {
++    SET_META ("AV1");
+   } else if (gst_structure_has_name (s, "video/x-bayer")) {
+     SET_META ("BAYER");
+   } else if (gst_structure_has_name (s, "video/x-sonix")) {
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0006-v4l2-decoder-Prefer-colorimetry-from-acquired-caps-f.patch
+++ b/gstreamer1.0-plugins-good/0006-v4l2-decoder-Prefer-colorimetry-from-acquired-caps-f.patch
@@ -1,0 +1,44 @@
+From 111ea47c78730033eece9a56ea7f8fa965109239 Mon Sep 17 00:00:00 2001
+From: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+Date: Wed, 29 Jan 2025 19:07:33 +0530
+Subject: [PATCH 06/18] v4l2: decoder: Prefer colorimetry from acquired caps
+ for fixate
+
+Issue:
+By default, the caps fixation is taking the first value from the
+supported colorimetries. This is not being accepted by video driver.
+So, set_format is failing.
+
+Fix:
+Prefer colorimetry from acquired caps from the driver for fixate.
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2videodec.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/sys/v4l2/gstv4l2videodec.c b/sys/v4l2/gstv4l2videodec.c
+index 8fbd18b..22bcf82 100644
+--- a/sys/v4l2/gstv4l2videodec.c
++++ b/sys/v4l2/gstv4l2videodec.c
+@@ -504,6 +504,16 @@ gst_v4l2_video_dec_negotiate (GstVideoDecoder * decoder)
+   if (gst_caps_is_subset (acquired_caps, caps))
+     goto use_acquired_caps;
+ 
++  /* Prefer colorimetry from acquired caps for fixate */
++  {
++    GstStructure *st = gst_caps_get_structure (acquired_caps, 0);
++    GstStructure *temp_st = gst_caps_get_structure (caps, 0);
++    gst_structure_fixate_field_string (temp_st, "colorimetry",
++        gst_structure_get_string(st, "colorimetry"));
++    GST_DEBUG_OBJECT (self, "After colorimetry fixation caps: %" GST_PTR_FORMAT,
++        caps);
++  }
++
+   /* Fixate pixel format */
+   caps = gst_caps_fixate (caps);
+ 
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0007-v4l2-enc-Set-sink-format-before-src-format.patch
+++ b/gstreamer1.0-plugins-good/0007-v4l2-enc-Set-sink-format-before-src-format.patch
@@ -1,0 +1,41 @@
+From ec977abc60415fb000dc993c1f15060bdbe39195 Mon Sep 17 00:00:00 2001
+From: Tushar Patra Jamula <tjamula@qti.qualcomm.com>
+Date: Thu, 6 Feb 2025 20:09:22 +0530
+Subject: [PATCH 07/18] v4l2: enc: Set sink format before src format
+
+Issue: Driver is providing default resolution instead of the required resolution if S_FMT of sink(output) is not set before S_FMT of src(capture).
+
+Fix: Set sink format before src format
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+
+Signed-off-by: Tushar Patra Jamula <tjamula@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2videoenc.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/sys/v4l2/gstv4l2videoenc.c b/sys/v4l2/gstv4l2videoenc.c
+index 5cd027b..f831f96 100644
+--- a/sys/v4l2/gstv4l2videoenc.c
++++ b/sys/v4l2/gstv4l2videoenc.c
+@@ -391,14 +391,14 @@ gst_v4l2_video_enc_set_format (GstVideoEncoder * encoder,
+     }
+   }
+ 
+-  if (!gst_video_encoder_negotiate (encoder))
+-    return FALSE;
+-
+   if (!gst_v4l2_object_set_format (self->v4l2output, state->caps, &error)) {
+     gst_v4l2_error (self, &error);
+     return FALSE;
+   }
+ 
++  if (!gst_video_encoder_negotiate (encoder))
++    return FALSE;
++
+   /* best effort */
+   gst_v4l2_object_setup_padding (self->v4l2output);
+ 
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0008-v4l2-Use-internal-DMA-buffer-pool-even-without-video.patch
+++ b/gstreamer1.0-plugins-good/0008-v4l2-Use-internal-DMA-buffer-pool-even-without-video.patch
@@ -1,0 +1,50 @@
+From 568a83775ba6d142a28e6435c0ae8ce4238cab91 Mon Sep 17 00:00:00 2001
+From: Stilyan Uzunov <suzunov@qti.qualcomm.com>
+Date: Wed, 26 Mar 2025 18:50:32 +0000
+Subject: [PATCH 08/18] v4l2: Use internal DMA buffer pool even without video
+ meta.
+
+Issue: V4L2 Decoder copy output data in system memory pool.
+
+Analysis: V4L2 plugins forward internal DMA buffers only if
+there is video meta in allocation query. But some elements
+does not interested by allocation query.
+
+Fix: Avoid buffer copy by forward DMA buffer even if next
+plugins do not required video meta. This is especially
+useful in case of pipelines where there is a Tee element.
+The Tee element does not propagate Video meta in allocation
+query one of downstream elements does not set video meta.
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+Signed-off-by: Konstantin Motov <kmotov@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2object.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index dcbe0eb..c4a2da6 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -5703,7 +5703,8 @@ gst_v4l2_object_decide_allocation (GstV4l2Object * obj, GstQuery * query)
+   guint size, min, max, own_min = 0;
+   gboolean update;
+   gboolean has_video_meta;
+-  gboolean can_share_own_pool, pushing_from_our_pool = FALSE;
++  gboolean can_share_own_pool = TRUE;
++  gboolean pushing_from_our_pool = FALSE;
+   GstAllocator *allocator = NULL;
+   GstAllocationParams params = { 0 };
+   guint video_idx;
+@@ -5752,8 +5753,6 @@ gst_v4l2_object_decide_allocation (GstV4l2Object * obj, GstQuery * query)
+       gst_v4l2_object_match_buffer_layout_from_struct (obj, params, caps, size);
+   }
+ 
+-  can_share_own_pool = (has_video_meta || !obj->need_video_meta);
+-
+   gst_v4l2_get_driver_min_buffers (obj);
+   /* We can't share our own pool, if it exceed V4L2 capacity */
+   if (min + obj->min_buffers + 1 > VIDEO_MAX_FRAME)
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0009-v4l2-fix-runtime-change-between-system-and-DMA-buffe.patch
+++ b/gstreamer1.0-plugins-good/0009-v4l2-fix-runtime-change-between-system-and-DMA-buffe.patch
@@ -1,0 +1,39 @@
+From 87eaa96a1310495ae40325c39e4370720b921fac Mon Sep 17 00:00:00 2001
+From: Stilyan Uzunov <suzunov@qti.qualcomm.com>
+Date: Wed, 26 Mar 2025 18:59:10 +0000
+Subject: [PATCH 09/18] v4l2: fix runtime change between system and DMA buffers
+
+Issue: Ruining V4L2 decoder with downstream needs FD
+buffer some time fails because decoder sometimes sends non-FD buffer.
+
+Analysis: V4L2 buffer pool copy DMA buffer in system memory buffer
+is number of free buffers are bellow some threshold. This feature
+is enable by V4L2 object when downstream does not propose
+buffer pool. But the issues are that decoder is configured to
+work on DMA export mode downstream buffer pool will be not used
+anyway.
+
+Fix: Disable buffer copy if DMA buffers are used.
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+Signed-off-by: Konstantin Motov <kmotov@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2object.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index c4a2da6..c588547 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -5838,7 +5838,7 @@ gst_v4l2_object_decide_allocation (GstV4l2Object * obj, GstQuery * query)
+ 
+     /* If no allocation parameters where provided, allow for a little more
+      * buffers and enable copy threshold */
+-    if (!update) {
++    if (!update && obj->mode != GST_V4L2_IO_DMABUF) {
+       own_min += 2;
+       gst_v4l2_buffer_pool_copy_at_threshold (GST_V4L2_BUFFER_POOL (pool),
+           TRUE);
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0010-v4l2-Send-video-alignment-in-allocation-query.patch
+++ b/gstreamer1.0-plugins-good/0010-v4l2-Send-video-alignment-in-allocation-query.patch
@@ -1,0 +1,58 @@
+From 796f95370e05849f3ff680a43963a4b74bbc25c7 Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Fri, 28 Mar 2025 09:00:03 +0000
+Subject: [PATCH 10/18] v4l2: Send video alignment in allocation query
+
+- Send video alignment in allocation query, so that upstream plugin can
+  consume this information when allocation query is returned
+- Send GstAllocationParams padding in allocation query
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+Signed-off-by: Pratik Pachange <ppachang@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2object.c | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index c588547..caed821 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -5997,6 +5997,7 @@ gst_v4l2_object_propose_allocation (GstV4l2Object * obj, GstQuery * query)
+   guint size, min, max;
+   GstCaps *caps;
+   gboolean need_pool;
++  GstAllocationParams a_params;
+   GstStructure *allocation_meta = NULL;
+ 
+   /* Set defaults allocation parameters */
+@@ -6047,6 +6048,27 @@ gst_v4l2_object_propose_allocation (GstV4l2Object * obj, GstQuery * query)
+ 
+   min = MAX (obj->min_buffers, GST_V4L2_MIN_BUFFERS (obj));
+ 
++  /* allocation params */
++  gst_allocation_params_init (&a_params);
++
++  if (V4L2_TYPE_IS_MULTIPLANAR (obj->type)) {
++    struct v4l2_pix_format_mplane *pix_mp = &obj->format.fmt.pix_mp;
++    gint i;
++
++    for (i = 0, size = 0; i < pix_mp->num_planes; i++)
++      size += pix_mp->plane_fmt[i].sizeimage;
++  } else {
++    size = obj->format.fmt.pix.sizeimage;
++  }
++
++  a_params.padding = size - GST_V4L2_SIZE (obj);
++
++  if (a_params.padding) {
++    GST_DEBUG_OBJECT (obj->dbg_obj, "allocation params padding:%" G_GSIZE_FORMAT,
++        a_params.padding);
++    gst_query_add_allocation_param (query, NULL, &a_params);
++  }
++
+   gst_query_add_allocation_pool (query, pool, size, min, max);
+ 
+   if (obj->align.padding_top || obj->align.padding_bottom ||
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0011-v4l2-Drop-empty-bytesused-0-buffers.patch
+++ b/gstreamer1.0-plugins-good/0011-v4l2-Drop-empty-bytesused-0-buffers.patch
@@ -1,0 +1,67 @@
+From 7f4acf679da620fc73572f75e7b7ae06f118ad61 Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Fri, 28 Mar 2025 09:18:53 +0000
+Subject: [PATCH 11/18] v4l2: Drop empty (bytesused 0) buffers
+
+Upstream-Status: Pending
+
+Signed-off-by: Pratik Pachange <ppachang@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2bufferpool.c | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/sys/v4l2/gstv4l2bufferpool.c b/sys/v4l2/gstv4l2bufferpool.c
+index 840e0f9..826b084 100644
+--- a/sys/v4l2/gstv4l2bufferpool.c
++++ b/sys/v4l2/gstv4l2bufferpool.c
+@@ -1352,6 +1352,9 @@ gst_v4l2_buffer_pool_dqbuf (GstV4l2BufferPool * pool, GstBuffer ** buffer,
+         group->planes[i].bytesused, i, group->buffer.flags,
+         GST_TIME_ARGS (timestamp), pool->num_queued, outbuf, old_buffer_state);
+ 
++    if (group->planes[i].bytesused == 0)
++      GST_BUFFER_FLAG_SET (outbuf, GST_BUFFER_FLAG_DROPPABLE);
++
+     if (GST_VIDEO_INFO_FORMAT (&pool->caps_info.vinfo) ==
+         GST_VIDEO_FORMAT_ENCODED)
+       break;
+@@ -1985,6 +1988,11 @@ gst_v4l2_buffer_pool_process (GstV4l2BufferPool * pool, GstBuffer ** buf,
+                 GST_VIDEO_FORMAT_ENCODED && size < pool->size)
+               goto buffer_truncated;
+ 
++            if (GST_BUFFER_FLAG_IS_SET (*buf, GST_BUFFER_FLAG_DROPPABLE)) {
++              GST_BUFFER_FLAG_UNSET (*buf, GST_BUFFER_FLAG_DROPPABLE);
++              goto drop_buffer;
++            }
++
+             num_queued = g_atomic_int_get (&pool->num_queued);
+             GST_TRACE_OBJECT (pool, "Only %i buffer left in the capture queue.",
+                 num_queued);
+@@ -2046,6 +2054,11 @@ gst_v4l2_buffer_pool_process (GstV4l2BufferPool * pool, GstBuffer ** buf,
+           /* an queue the buffer again after the copy */
+           gst_v4l2_buffer_pool_complete_release_buffer (bpool, tmp, FALSE);
+ 
++          if (GST_BUFFER_FLAG_IS_SET (tmp, GST_BUFFER_FLAG_DROPPABLE)) {
++            GST_BUFFER_FLAG_UNSET (tmp, GST_BUFFER_FLAG_DROPPABLE);
++            goto drop_buffer;
++          }
++
+           if (ret != GST_FLOW_OK)
+             goto copy_failed;
+           break;
+@@ -2289,6 +2302,13 @@ start_failed:
+     GST_ERROR_OBJECT (pool, "failed to start streaming");
+     return GST_FLOW_ERROR;
+   }
++drop_buffer:
++  {
++    GST_WARNING_OBJECT (pool, "dropping 0 length buffer");
++    gst_buffer_unref (*buf);
++    *buf = NULL;
++    return GST_V4L2_FLOW_CORRUPTED_BUFFER;
++  }
+ }
+ 
+ void
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0012-v4l2-Add-KEEP_MAPPED-flag-to-the-allocated-buffers.patch
+++ b/gstreamer1.0-plugins-good/0012-v4l2-Add-KEEP_MAPPED-flag-to-the-allocated-buffers.patch
@@ -1,0 +1,30 @@
+From 7b485e1af72e1f2c55ed2c213ecb87d3463dedac Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Fri, 28 Mar 2025 09:24:56 +0000
+Subject: [PATCH 12/18] v4l2: Add KEEP_MAPPED flag to the allocated buffers
+
+ - This flag prevents the same buffer from being mapped twice.
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+Signed-off-by: Pratik Pachange <ppachang@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2allocator.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/sys/v4l2/gstv4l2allocator.c b/sys/v4l2/gstv4l2allocator.c
+index 4176f9e..14cae48 100644
+--- a/sys/v4l2/gstv4l2allocator.c
++++ b/sys/v4l2/gstv4l2allocator.c
+@@ -934,7 +934,8 @@ gst_v4l2_allocator_alloc_dmabuf (GstV4l2Allocator * allocator,
+     mem = (GstV4l2Memory *) group->mem[i];
+ 
+     dma_mem = gst_fd_allocator_alloc (dmabuf_allocator, mem->dmafd,
+-        group->planes[i].length, GST_FD_MEMORY_FLAG_DONT_CLOSE);
++        group->planes[i].length,
++        GST_FD_MEMORY_FLAG_DONT_CLOSE | GST_FD_MEMORY_FLAG_KEEP_MAPPED);
+     gst_memory_resize (dma_mem, group->planes[i].data_offset,
+         group->planes[i].length - group->planes[i].data_offset);
+ 
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0013-v4l2-Handle-GAP-buffer-in-encoder.patch
+++ b/gstreamer1.0-plugins-good/0013-v4l2-Handle-GAP-buffer-in-encoder.patch
@@ -1,0 +1,28 @@
+From da94a20c0aca4e80e21803a7cbded57367548a01 Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Fri, 28 Mar 2025 09:30:39 +0000
+Subject: [PATCH 13/18] v4l2: Handle GAP buffer in encoder
+
+Upstream-Status: Pending
+Signed-off-by: Pratik Pachange <ppachang@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2videoenc.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/sys/v4l2/gstv4l2videoenc.c b/sys/v4l2/gstv4l2videoenc.c
+index f831f96..b1929d0 100644
+--- a/sys/v4l2/gstv4l2videoenc.c
++++ b/sys/v4l2/gstv4l2videoenc.c
+@@ -790,6 +790,9 @@ gst_v4l2_video_enc_handle_frame (GstVideoEncoder * encoder,
+   if (G_UNLIKELY (!g_atomic_int_get (&self->active)))
+     goto flushing;
+ 
++  if (GST_BUFFER_FLAG_IS_SET (frame->input_buffer, GST_BUFFER_FLAG_GAP))
++    goto drop;
++
+   task_state = gst_pad_get_task_state (GST_VIDEO_ENCODER_SRC_PAD (self));
+   if (task_state == GST_TASK_STOPPED || task_state == GST_TASK_PAUSED) {
+     /* It is possible that the processing thread stopped due to an error or
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0014-v4l2-Set-extra-controls-if-pixelformat-is-updated.patch
+++ b/gstreamer1.0-plugins-good/0014-v4l2-Set-extra-controls-if-pixelformat-is-updated.patch
@@ -1,0 +1,133 @@
+From 323a48b9556def1038c45096d9e955b2ed1b8402 Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Fri, 28 Mar 2025 09:41:15 +0000
+Subject: [PATCH 14/18] v4l2: Set extra controls if pixelformat is updated
+
+Upstream-Status: Pending
+Signed-off-by: Pratik Pachange <ppachang@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2object.c   |  2 +-
+ sys/v4l2/gstv4l2object.h   |  3 +++
+ sys/v4l2/gstv4l2videoenc.c | 51 ++++++++++++++++++++++----------------
+ sys/v4l2/v4l2_calls.c      |  2 +-
+ 4 files changed, 34 insertions(+), 24 deletions(-)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index caed821..1d4b991 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -1967,7 +1967,7 @@ gst_v4l2_object_probe_template_caps (const gchar * device, gint video_fd,
+  * @fps_n/@fps_d: location for framerate
+  * @size: location for expected size of the frame or 0 if unknown
+  */
+-static gboolean
++gboolean
+ gst_v4l2_object_get_caps_info (GstV4l2Object * v4l2object, GstCaps * caps,
+     struct v4l2_fmtdesc **format, GstVideoInfoDmaDrm * info)
+ {
+diff --git a/sys/v4l2/gstv4l2object.h b/sys/v4l2/gstv4l2object.h
+index 4b14b7e..a728beb 100644
+--- a/sys/v4l2/gstv4l2object.h
++++ b/sys/v4l2/gstv4l2object.h
+@@ -309,6 +309,7 @@ gboolean     gst_v4l2_object_try_import  (GstV4l2Object * v4l2object, GstBuffer
+ gboolean     gst_v4l2_object_caps_equal       (GstV4l2Object * v4l2object, GstCaps * caps);
+ gboolean     gst_v4l2_object_caps_is_subset   (GstV4l2Object * v4l2object, GstCaps * caps);
+ GstCaps *    gst_v4l2_object_get_current_caps (GstV4l2Object * v4l2object);
++gboolean     gst_v4l2_object_get_caps_info    (GstV4l2Object * v4l2object, GstCaps * caps, struct v4l2_fmtdesc **format, GstVideoInfoDmaDrm * info);
+ 
+ gboolean     gst_v4l2_object_unlock      (GstV4l2Object * v4l2object);
+ gboolean     gst_v4l2_object_unlock_stop (GstV4l2Object * v4l2object);
+@@ -374,6 +375,8 @@ gboolean     gst_v4l2_set_controls    (GstV4l2Object * v4l2object, GstStructure
+ gboolean     gst_v4l2_subscribe_event (GstV4l2Object * v4l2object, guint32 event, guint32 id);
+ gboolean     gst_v4l2_dequeue_event   (GstV4l2Object * v4l2object, struct v4l2_event *event);
+ 
++gboolean     gst_v4l2_fill_lists (GstV4l2Object * v4l2object);
++
+ G_END_DECLS
+ 
+ #endif /* __GST_V4L2_OBJECT_H__ */
+diff --git a/sys/v4l2/gstv4l2videoenc.c b/sys/v4l2/gstv4l2videoenc.c
+index b1929d0..acae573 100644
+--- a/sys/v4l2/gstv4l2videoenc.c
++++ b/sys/v4l2/gstv4l2videoenc.c
+@@ -360,35 +360,42 @@ gst_v4l2_video_enc_set_format (GstVideoEncoder * encoder,
+   {
+     GstV4l2Object *v4l2object = GST_V4L2_OBJECT (self->v4l2capture);
+     struct v4l2_format format;
+-    GstStructure *s;
+-    const gchar *mimetype;
+-
+-    s = gst_caps_get_structure(outcaps, 0);
+-    mimetype = gst_structure_get_name (s);
+-
+-    if (g_str_equal (mimetype, "video/x-h265")) {
+-      memset (&format, 0x00, sizeof (struct v4l2_format));
+-      format.type = v4l2object->type;
+-      if (v4l2object->ioctl (v4l2object->video_fd, VIDIOC_G_FMT, &format) < 0) {
+-        GST_ERROR_OBJECT (self, "Failed to call VIDIOC_G_FMT with error %s",
+-            g_strerror (errno));
+-        return FALSE;
+-      }
+-      GST_DEBUG_OBJECT (self, "Initial pixel format returned by VIDIOC_G_FMT: %"
+-          GST_FOURCC_FORMAT, GST_FOURCC_ARGS (format.fmt.pix.pixelformat));
++    struct v4l2_fmtdesc *fmtdesc;
++    GstVideoInfoDmaDrm info;
++    GstCaps *caps = gst_caps_copy (outcaps);
++    GstStructure *s = gst_caps_get_structure (caps, 0);
++
++    gst_structure_remove_all_fields (s);
++    gst_video_info_dma_drm_init (&info);
++    if (!gst_v4l2_object_get_caps_info (v4l2object, caps, &fmtdesc, &info))
++      return FALSE;
++
++    memset (&format, 0x00, sizeof (struct v4l2_format));
++    format.type = v4l2object->type;
++    if (v4l2object->ioctl (v4l2object->video_fd, VIDIOC_G_FMT, &format) < 0) {
++      GST_ERROR_OBJECT (self, "Call to VIDIOC_G_FMT failed with error %s",
++          g_strerror (errno));
++      return FALSE;
++    }
+ 
+-      // Overriding the pixel format with H265
+-      format.fmt.pix.pixelformat = V4L2_PIX_FMT_HEVC;
++    if (format.fmt.pix.pixelformat != fmtdesc->pixelformat) {
++      format.fmt.pix.pixelformat = fmtdesc->pixelformat;
+       if (v4l2object->ioctl (v4l2object->video_fd, VIDIOC_S_FMT, &format) < 0) {
+-        GST_ERROR_OBJECT (self, "Failed to call VIDIOC_S_FMT for format %"
++        GST_ERROR_OBJECT (self, "Call to VIDIOC_S_FMT failed for format %"
+             GST_FOURCC_FORMAT " with error %s",
+-            GST_FOURCC_ARGS (format.fmt.pix.pixelformat),
+-            g_strerror (errno));
++            GST_FOURCC_ARGS (format.fmt.pix.pixelformat), g_strerror (errno));
+         return FALSE;
+       }
+-      GST_DEBUG_OBJECT (self, "Pixel format set to %" GST_FOURCC_FORMAT,
++      GST_DEBUG_OBJECT (self, "pixelformat set to %" GST_FOURCC_FORMAT,
+           GST_FOURCC_ARGS (format.fmt.pix.pixelformat));
++
++      gst_v4l2_fill_lists (self->v4l2output);
++      if (self->v4l2output->extra_controls) {
++        gst_v4l2_set_controls (self->v4l2output, self->v4l2output->extra_controls);
++      }
+     }
++
++    gst_caps_unref (caps);
+   }
+ 
+   if (!gst_v4l2_object_set_format (self->v4l2output, state->caps, &error)) {
+diff --git a/sys/v4l2/v4l2_calls.c b/sys/v4l2/v4l2_calls.c
+index e1b58f4..4d94b72 100644
+--- a/sys/v4l2/v4l2_calls.c
++++ b/sys/v4l2/v4l2_calls.c
+@@ -125,7 +125,7 @@ gst_v4l2_normalise_control_name (gchar * name)
+  *   fill/empty the lists of enumerations
+  * return value: TRUE on success, FALSE on error
+  ******************************************************/
+-static gboolean
++gboolean
+ gst_v4l2_fill_lists (GstV4l2Object * v4l2object)
+ {
+   gint n, next;
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0015-v4l2-Fix-segmentation-fault.patch
+++ b/gstreamer1.0-plugins-good/0015-v4l2-Fix-segmentation-fault.patch
@@ -1,0 +1,27 @@
+From 25569170399212b4d2fe7250c8c1ed4a01db897c Mon Sep 17 00:00:00 2001
+From: Pratik Pachange <ppachang@qti.qualcomm.com>
+Date: Fri, 28 Mar 2025 09:44:55 +0000
+Subject: [PATCH 15/18] v4l2: Fix segmentation fault
+
+Upstream-Status: Pending
+Signed-off-by: Pratik Pachange <ppachang@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2object.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index 1d4b991..170f6aa 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -2036,7 +2036,7 @@ gst_v4l2_object_get_caps_info (GstV4l2Object * v4l2object, GstCaps * caps,
+   } else if (g_str_equal (mimetype, "video/x-h264")) {
+     const gchar *stream_format =
+         gst_structure_get_string (structure, "stream-format");
+-    if (g_str_equal (stream_format, "avc"))
++    if (stream_format && g_str_equal (stream_format, "avc"))
+       fourcc = V4L2_PIX_FMT_H264_NO_SC;
+     else
+       fourcc = V4L2_PIX_FMT_H264;
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0016-v4l2-consider-Q08C-as-contiguous-planes.patch
+++ b/gstreamer1.0-plugins-good/0016-v4l2-consider-Q08C-as-contiguous-planes.patch
@@ -1,0 +1,39 @@
+From 73e2b382afd0a78a9b029c581be0c26cc2999add Mon Sep 17 00:00:00 2001
+From: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+Date: Wed, 16 Apr 2025 17:55:42 +0530
+Subject: [PATCH 16/18] v4l2: consider Q08C as contiguous planes
+
+Issue:
+By default, the first match of gst_v4l2_formats is considered
+as non-contiguous planes. And the next match (fallback) as contiguous.
+But Q08C is contiguous planes and doesn't have non-contiguous equivalant.
+
+Fix:
+Consider the Q08C as contiguous planes. Re-assign the fourcc values.
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+
+Signed-off-by: Raja Ganapathi Busam <rbusam@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2object.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index 170f6aa..2221a28 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -2005,6 +2005,11 @@ gst_v4l2_object_get_caps_info (GstV4l2Object * v4l2object, GstCaps * caps,
+       fourcc_nc = desc->v4l2_format;
+     if (fallback_desc)
+       fourcc = fallback_desc->v4l2_format;
++
++    if (fourcc_nc == V4L2_PIX_FMT_QC08C) {
++      fourcc_nc = 0;
++      fourcc = V4L2_PIX_FMT_QC08C;
++    }
+   } else if (g_str_equal (mimetype, "video/mpegts")) {
+     fourcc = V4L2_PIX_FMT_MPEG;
+   } else if (g_str_equal (mimetype, "video/x-dv")) {
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0017-v4l2-Make-the-extra-controls-property-dynamic.patch
+++ b/gstreamer1.0-plugins-good/0017-v4l2-Make-the-extra-controls-property-dynamic.patch
@@ -1,0 +1,40 @@
+From 4791dc35f096429430aaff7cfba427ad4f02f168 Mon Sep 17 00:00:00 2001
+From: Tushar Patra Jamula <tjamula@qti.qualcomm.com>
+Date: Mon, 28 Apr 2025 18:20:27 +0530
+Subject: [PATCH 17/18] v4l2: Make the extra-controls property dynamic
+
+Upstream-Status: Inappropriate [Qualcomm Specific]
+
+Signed-off-by: Tushar Patra Jamula <tjamula@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2object.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index 2221a28..ca5dd5b 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -448,7 +448,9 @@ gst_v4l2_object_install_properties_helper (GObjectClass * gobject_class,
+   g_object_class_install_property (gobject_class, PROP_EXTRA_CONTROLS,
+       g_param_spec_boxed ("extra-controls", "Extra Controls",
+           "Extra v4l2 controls (CIDs) for the device",
+-          GST_TYPE_STRUCTURE, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
++          GST_TYPE_STRUCTURE,
++          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | GST_PARAM_MUTABLE_PLAYING));
++
+ 
+   /**
+    * GstV4l2Src:pixel-aspect-ratio:
+@@ -513,7 +515,8 @@ gst_v4l2_object_install_m2m_properties_helper (GObjectClass * gobject_class)
+   g_object_class_install_property (gobject_class, PROP_EXTRA_CONTROLS,
+       g_param_spec_boxed ("extra-controls", "Extra Controls",
+           "Extra v4l2 controls (CIDs) for the device",
+-          GST_TYPE_STRUCTURE, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
++          GST_TYPE_STRUCTURE,
++          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | GST_PARAM_MUTABLE_PLAYING));
+ }
+ 
+ /* Support for 32bit off_t, this wrapper is casting off_t to gint64 */
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-good/0018-v4l2-Backport-alternative-output-format-support.patch
+++ b/gstreamer1.0-plugins-good/0018-v4l2-Backport-alternative-output-format-support.patch
@@ -1,0 +1,37 @@
+From 171f093e79c4086ef4b29a39caec89ff696bfa28 Mon Sep 17 00:00:00 2001
+From: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+Date: Mon, 8 Dec 2025 12:41:44 +0000
+Subject: [PATCH 18/18] v4l2: Backport alternative output format support
+
+Some decoder have the ability to output multiple formats.
+Restore this functionality by replacing acquired_caps with the new caps.
+Backport from: https://salsa.debian.org/gstreamer-team/gst-plugins-good1.0/
+-/commit/323d9a3046d025da2ca8e43a5ea48ae0400c114c#c0a42aff914bd304990942c0548e70b44de4d1e2
+
+Upstream-Status: Backport
+
+Signed-off-by: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+---
+ sys/v4l2/gstv4l2videodec.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/sys/v4l2/gstv4l2videodec.c b/sys/v4l2/gstv4l2videodec.c
+index 22bcf82..8a8d8d5 100644
+--- a/sys/v4l2/gstv4l2videodec.c
++++ b/sys/v4l2/gstv4l2videodec.c
+@@ -520,9 +520,10 @@ gst_v4l2_video_dec_negotiate (GstVideoDecoder * decoder)
+   GST_DEBUG_OBJECT (self, "Chosen decoded caps: %" GST_PTR_FORMAT, caps);
+ 
+   /* Try to set negotiated format, on success replace acquired format */
+-  if (gst_v4l2_object_set_format (self->v4l2capture, caps, &error))
++  if (gst_v4l2_object_set_format (self->v4l2capture, caps, &error)) {
++    gst_caps_replace (&acquired_caps, caps);
+     info = self->v4l2capture->info;
+-  else
++  } else
+     gst_v4l2_clear_error (&error);
+ 
+ use_acquired_caps:
+-- 
+2.34.1
+


### PR DESCRIPTION
- v4l2: Backport alternative output format support
- v4l2: Make the extra-controls property dynamic
- v4l2: consider Q08C as contiguous planes
- v4l2: Fix segmentation fault
- v4l2: Set extra controls if pixelformat is updated
- v4l2: Handle GAP buffer in encoder
- v4l2: Add KEEP_MAPPED flag to the allocated buffers
- v4l2: Drop empty (bytesused 0) buffers
- v4l2: Send video alignment in allocation query
- v4l2: fix runtime change between system and DMA buffers
- v4l2: Use internal DMA buffer pool even without video meta.
- v4l2: enc: Set sink format before src format
- v4l2: decoder: Prefer colorimetry from acquired caps for fixate
- v4l2: Add support for AV1 format
- v4l2: Add support for fd memory import
- v4l2: Set pixel format to HEVC for H265 MIME type
- v4l2: Check for V4L2_BUF_FLAG_LAST flag to handle EOS
- v4l2: Add support for V4L2_PIX_FMT_QC08C format