### PR TITLE
gstreamer1.0-plugins-bad: Add patch files for version 1.26.2

### DIFF
--- a/gstreamer1.0-plugins-bad/0001-waylandsink-release-pending-buffers-in-composer.patch
+++ b/gstreamer1.0-plugins-bad/0001-waylandsink-release-pending-buffers-in-composer.patch
@@ -1,0 +1,193 @@
+From d065036f3dc7324aa386432333db9a9fb7c5a6f7 Mon Sep 17 00:00:00 2001
+From: "Petar G. Georgiev" <petarg@codeaurora.org>
+Date: Fri, 29 Nov 2019 14:56:55 +0200
+Subject: [PATCH 1/5] waylandsink: release pending buffers in composer
+
+- Add functionality to forcibly release any pending buffers in the
+  wayland compositor at GST_QUERY_DRAIN, GST_EVENT_FLUSH_START and
+  at GST_STATE_CHANGE_PAUSED_TO_READY.
+- This is needed because some live sources may require all buffers
+  to be returned when transitioning to READY state, some decoders
+  may want them returned when DRAIN query is sent or During FLUSH
+  events buffer must be returned as well.
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+
+Signed-off-by: Petar G. Georgiev <quic_petarg@quicinc.com>
+---
+ ext/wayland/gstwaylandsink.c        | 38 +++++++++++++++++++++++++++--
+ gst-libs/gst/wayland/gstwlbuffer.c  | 23 ++++++++---------
+ gst-libs/gst/wayland/gstwldisplay.c | 16 ++++++++++++
+ gst-libs/gst/wayland/gstwldisplay.h |  3 +++
+ 4 files changed, 67 insertions(+), 13 deletions(-)
+
+diff --git a/ext/wayland/gstwaylandsink.c b/ext/wayland/gstwaylandsink.c
+index 19a3e8c..4099750 100644
+--- a/ext/wayland/gstwaylandsink.c
++++ b/ext/wayland/gstwaylandsink.c
+@@ -87,6 +87,7 @@ static GstStateChangeReturn gst_wayland_sink_change_state (GstElement * element,
+ static void gst_wayland_sink_set_context (GstElement * element,
+     GstContext * context);
+ 
++static gboolean gst_wayland_sink_query (GstBaseSink * bsink, GstQuery * query);
+ static gboolean gst_wayland_sink_event (GstBaseSink * bsink, GstEvent * event);
+ static GstCaps *gst_wayland_sink_get_caps (GstBaseSink * bsink,
+     GstCaps * filter);
+@@ -142,6 +143,7 @@ gst_wayland_sink_class_init (GstWaylandSinkClass * klass)
+   gstelement_class->set_context =
+       GST_DEBUG_FUNCPTR (gst_wayland_sink_set_context);
+ 
++  gstbasesink_class->query = GST_DEBUG_FUNCPTR (gst_wayland_sink_query);
+   gstbasesink_class->event = GST_DEBUG_FUNCPTR (gst_wayland_sink_event);
+   gstbasesink_class->get_caps = GST_DEBUG_FUNCPTR (gst_wayland_sink_get_caps);
+   gstbasesink_class->set_caps = GST_DEBUG_FUNCPTR (gst_wayland_sink_set_caps);
+@@ -477,6 +479,7 @@ gst_wayland_sink_change_state (GstElement * element, GstStateChange transition)
+         }
+       }
+ 
++      gst_wl_display_force_release_buffers (self->display);
+       break;
+     case GST_STATE_CHANGE_READY_TO_NULL:
+       g_mutex_lock (&self->display_lock);
+@@ -527,6 +530,30 @@ gst_wayland_sink_set_context (GstElement * element, GstContext * context)
+     GST_ELEMENT_CLASS (parent_class)->set_context (element, context);
+ }
+ 
++static gboolean
++gst_wayland_sink_query (GstBaseSink * bsink, GstQuery * query)
++{
++  GstWaylandSink *self = GST_WAYLAND_SINK (bsink);
++  gboolean ret;
++
++  GST_DEBUG_OBJECT (self, "handling %s query", GST_QUERY_TYPE_NAME (query));
++
++  /* First execute the parent class query function. */
++  ret = GST_BASE_SINK_CLASS (parent_class)->query (bsink, query);
++
++  switch (GST_QUERY_TYPE (query)) {
++    case GST_QUERY_DRAIN:
++      /* Force release any buffers in the wayland composer. */
++      gst_buffer_replace (&self->last_buffer, NULL);
++      gst_wl_display_force_release_buffers (self->display);
++      break;
++    default:
++      break;
++  }
++
++  return ret;
++}
++
+ static gboolean
+ gst_wayland_sink_event (GstBaseSink * bsink, GstEvent * event)
+ {
+@@ -537,6 +564,9 @@ gst_wayland_sink_event (GstBaseSink * bsink, GstEvent * event)
+ 
+   GST_DEBUG_OBJECT (self, "handling %s event", GST_EVENT_TYPE_NAME (event));
+ 
++  /* First execute the parent class event function. */
++  ret = GST_BASE_SINK_CLASS (parent_class)->event (bsink, gst_event_ref (event));
++
+   switch (GST_EVENT_TYPE (event)) {
+     case GST_EVENT_TAG:
+       gst_event_parse_tag (event, &taglist);
+@@ -545,13 +575,17 @@ gst_wayland_sink_event (GstBaseSink * bsink, GstEvent * event)
+         gst_wayland_sink_set_rotate_method (self, method, TRUE);
+       }
+ 
++      break;
++    case GST_EVENT_FLUSH_START:
++      /* Force release any buffers in the wayland composer. */
++      gst_buffer_replace (&self->last_buffer, NULL);
++      gst_wl_display_force_release_buffers (self->display);
+       break;
+     default:
+       break;
+   }
+ 
+-  ret = GST_BASE_SINK_CLASS (parent_class)->event (bsink, event);
+-
++  gst_event_unref (event);
+   return ret;
+ }
+ 
+diff --git a/gst-libs/gst/wayland/gstwlbuffer.c b/gst-libs/gst/wayland/gstwlbuffer.c
+index 988c7b6..16e8678 100644
+--- a/gst-libs/gst/wayland/gstwlbuffer.c
++++ b/gst-libs/gst/wayland/gstwlbuffer.c
+@@ -234,17 +234,6 @@ gst_wl_buffer_force_release_and_unref (GstBuffer * buf, GstWlBuffer * self)
+ {
+   GstWlBufferPrivate *priv = gst_wl_buffer_get_instance_private (self);
+ 
+-  /* Force a buffer release.
+-   * At this point, the GstWlDisplay has killed its event loop,
+-   * so we don't need to worry about buffer_release() being called
+-   * at the same time from the event loop thread */
+-  if (priv->used_by_compositor) {
+-    GST_DEBUG_OBJECT (self, "forcing wl_buffer::release (GstBuffer: %p)",
+-        priv->current_gstbuffer);
+-    priv->used_by_compositor = FALSE;
+-    gst_buffer_unref (priv->current_gstbuffer);
+-  }
+-
+   /* Finalize this GstWlBuffer early.
+    * This method has been called as a result of the display shutting down,
+    * so we need to stop using any wayland resources and disconnect from
+@@ -256,6 +245,18 @@ gst_wl_buffer_force_release_and_unref (GstBuffer * buf, GstWlBuffer * self)
+   wl_buffer_destroy (priv->wlbuffer);
+   priv->wlbuffer = NULL;
+   priv->display = NULL;
++
++  /* Force a buffer release.
++   * At this point, the GstWlDisplay has killed its event loop,
++   * so we don't need to worry about buffer_release() being called
++   * at the same time from the event loop thread */
++  if (priv->used_by_compositor) {
++    GST_DEBUG_OBJECT (self, "forcing wl_buffer::release (GstBuffer: %p)",
++        priv->current_gstbuffer);
++    priv->used_by_compositor = FALSE;
++    gst_buffer_unref (priv->current_gstbuffer);
++  }
++
+   priv->current_gstbuffer = NULL;
+ 
+   /* remove the reference that the caller (GstWlDisplay) owns */
+diff --git a/gst-libs/gst/wayland/gstwldisplay.c b/gst-libs/gst/wayland/gstwldisplay.c
+index abc8327..a73c3f1 100644
+--- a/gst-libs/gst/wayland/gstwldisplay.c
++++ b/gst-libs/gst/wayland/gstwldisplay.c
+@@ -760,3 +760,19 @@ gst_wl_display_has_own_display (GstWlDisplay * self)
+ 
+   return priv->own_display;
+ }
++
++void
++gst_wl_display_force_release_buffers (GstWlDisplay * self)
++{
++  GstWlDisplayPrivate *priv = gst_wl_display_get_instance_private (self);
++
++  /* to avoid buffers being unregistered from another thread
++   * at the same time, take their ownership */
++  g_mutex_lock (&priv->buffers_mutex);
++  g_hash_table_foreach (priv->buffers, gst_wl_ref_wl_buffer, NULL);
++  g_mutex_unlock (&priv->buffers_mutex);
++
++  g_hash_table_foreach (priv->buffers,
++      (GHFunc) gst_wl_buffer_force_release_and_unref, NULL);
++  g_hash_table_remove_all (priv->buffers);
++}
+\ No newline at end of file
+diff --git a/gst-libs/gst/wayland/gstwldisplay.h b/gst-libs/gst/wayland/gstwldisplay.h
+index b2f0ca3..a4b3803 100644
+--- a/gst-libs/gst/wayland/gstwldisplay.h
++++ b/gst-libs/gst/wayland/gstwldisplay.h
+@@ -121,4 +121,7 @@ struct wp_single_pixel_buffer_manager_v1 * gst_wl_display_get_single_pixel_buffe
+ GST_WL_API
+ gboolean gst_wl_display_has_own_display (GstWlDisplay * self);
+ 
++GST_WL_API
++void gst_wl_display_force_release_buffers (GstWlDisplay * self);
++
+ G_END_DECLS
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-bad/0002-waylandsink-support-gap-buffers.patch
+++ b/gstreamer1.0-plugins-bad/0002-waylandsink-support-gap-buffers.patch
@@ -1,0 +1,35 @@
+From 99d02f955bc42a367aafb4c45faeed53081c4e55 Mon Sep 17 00:00:00 2001
+From: "Petar G. Georgiev" <quic_petarg@quicinc.com>
+Date: Thu, 18 May 2023 11:38:14 +0300
+Subject: [PATCH 2/5] waylandsink: support gap buffers
+
+- When a GAP buffer is received for rendering, simply drop it.
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+
+Signed-off-by: Petar G. Georgiev <quic_petarg@quicinc.com>
+---
+ ext/wayland/gstwaylandsink.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/ext/wayland/gstwaylandsink.c b/ext/wayland/gstwaylandsink.c
+index 4099750..b76b48f 100644
+--- a/ext/wayland/gstwaylandsink.c
++++ b/ext/wayland/gstwaylandsink.c
+@@ -903,6 +903,13 @@ gst_wayland_sink_show_frame (GstVideoSink * vsink, GstBuffer * buffer)
+     }
+   }
+ 
++  /* GAP buffer, nothing further to do */
++  if (gst_buffer_get_size (buffer) == 0 &&
++      GST_BUFFER_FLAG_IS_SET (buffer, GST_BUFFER_FLAG_GAP)) {
++    GST_LOG_OBJECT (self, "buffer %p dropped (gap in the stream)", buffer);
++    goto done;
++  }
++
+   /* make sure that the application has called set_render_rectangle() */
+   if (G_UNLIKELY (gst_wl_window_get_render_rectangle (self->window)->w == 0))
+     goto no_window_size;
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-bad/0003-waylandsink-increase-timeout-limitation-in-gst_wl_wi.patch
+++ b/gstreamer1.0-plugins-bad/0003-waylandsink-increase-timeout-limitation-in-gst_wl_wi.patch
@@ -1,0 +1,35 @@
+From 3ebc0b19c256472665d2cc3e9f04409f251627ef Mon Sep 17 00:00:00 2001
+From: Raja Ganapathi Busam <quic_rbusam@quicinc.com>
+Date: Wed, 5 Mar 2025 15:32:42 +0530
+Subject: [PATCH 3/5] waylandsink: increase timeout limitation in
+ gst_wl_window_new_toplevel
+
+- Issue: There is no enough time for xdg surface configuring in stress
+         tests of activate-deactivate example and EIS case. In this
+         case, it will report "xdg_toplevel@17: error 1: Surface has not
+         been configured yet".
+- Fix: Increase timeout limitation in gst_wl_window_new_toplevel.
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+
+Signed-off-by: Raja Ganapathi Busam <quic_rbusam@quicinc.com>
+---
+ gst-libs/gst/wayland/gstwlwindow.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gst-libs/gst/wayland/gstwlwindow.c b/gst-libs/gst/wayland/gstwlwindow.c
+index 2543d26..8900b80 100644
+--- a/gst-libs/gst/wayland/gstwlwindow.c
++++ b/gst-libs/gst/wayland/gstwlwindow.c
+@@ -343,7 +343,7 @@ gst_wl_window_new_toplevel (GstWlDisplay * display, const GstVideoInfo * info,
+     wl_display_flush (gst_wl_display_get_display (display));
+ 
+     g_mutex_lock (&priv->configure_mutex);
+-    timeout = g_get_monotonic_time () + 100 * G_TIME_SPAN_MILLISECOND;
++    timeout = g_get_monotonic_time () + 200 * G_TIME_SPAN_MILLISECOND;
+     while (!priv->configured) {
+       if (!g_cond_wait_until (&priv->configure_cond, &priv->configure_mutex,
+               timeout)) {
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-bad/0004-wayland-Add-support-for-NV12_Q08C-compressed-8-bit-f.patch
+++ b/gstreamer1.0-plugins-bad/0004-wayland-Add-support-for-NV12_Q08C-compressed-8-bit-f.patch
@@ -1,0 +1,100 @@
+From 0d7d087ee2a0bf607e2314ac6967f839c282438f Mon Sep 17 00:00:00 2001
+From: Raja Ganapathi Busam <quic_rbusam@quicinc.com>
+Date: Thu, 17 Apr 2025 15:27:32 +0530
+Subject: [PATCH 4/5] wayland: Add support for NV12_Q08C (compressed 8-bit)
+ format
+
+- Add NV12_Q08C to static caps
+- Update the modifier value in set_caps for NV12_Q08C
+- Add is_fd_memory checks along with dmabuf to check GstMemory
+
+Upstream-Status: Inappropriate [Qualcomm specific]
+
+Signed-off-by: Raja Ganapathi Busam <quic_rbusam@quicinc.com>
+---
+ ext/wayland/gstwaylandsink.c            | 14 +++++++++++++-
+ gst-libs/gst/wayland/gstwllinuxdmabuf.c |  2 +-
+ gst-libs/gst/wayland/gstwlvideoformat.c |  1 +
+ gst-libs/gst/wayland/gstwlvideoformat.h |  6 ++++--
+ 4 files changed, 19 insertions(+), 4 deletions(-)
+
+diff --git a/ext/wayland/gstwaylandsink.c b/ext/wayland/gstwaylandsink.c
+index b76b48f..1835db0 100644
+--- a/ext/wayland/gstwaylandsink.c
++++ b/ext/wayland/gstwaylandsink.c
+@@ -740,6 +740,17 @@ gst_wayland_sink_set_caps (GstBaseSink * bsink, GstCaps * caps)
+     if (!gst_video_info_dma_drm_from_video_info (&self->drm_info,
+             &self->video_info, DRM_FORMAT_MOD_LINEAR))
+       gst_video_info_dma_drm_init (&self->drm_info);
++
++    if (GST_VIDEO_INFO_FORMAT (&self->video_info) == GST_VIDEO_FORMAT_NV12_Q08C) {
++      self->drm_info.vinfo = self->video_info;
++      self->drm_info.drm_fourcc = gst_video_dma_drm_fourcc_from_format (
++          GST_VIDEO_FORMAT_NV12);
++      self->drm_info.drm_modifier = DRM_FORMAT_MOD_QCOM_COMPRESSED;
++
++      GST_DEBUG_OBJECT (self, "DRM format %" GST_FOURCC_FORMAT " Modifier "
++          "0x%016" G_GINT64_MODIFIER "x", GST_FOURCC_ARGS (
++              self->drm_info.drm_fourcc), self->drm_info.drm_modifier);
++    }
+   }
+ 
+   self->video_info_changed = TRUE;
+@@ -936,7 +947,8 @@ gst_wayland_sink_show_frame (GstVideoSink * vsink, GstBuffer * buffer)
+     guint i, nb_dmabuf = 0;
+ 
+     for (i = 0; i < gst_buffer_n_memory (buffer); i++)
+-      if (gst_is_dmabuf_memory (gst_buffer_peek_memory (buffer, i)))
++      if (gst_is_dmabuf_memory (gst_buffer_peek_memory (buffer, i)) ||
++          gst_is_fd_memory (gst_buffer_peek_memory (buffer, i)))
+         nb_dmabuf++;
+ 
+     if (nb_dmabuf && (nb_dmabuf == gst_buffer_n_memory (buffer)))
+diff --git a/gst-libs/gst/wayland/gstwllinuxdmabuf.c b/gst-libs/gst/wayland/gstwllinuxdmabuf.c
+index 54c5811..6723212 100644
+--- a/gst-libs/gst/wayland/gstwllinuxdmabuf.c
++++ b/gst-libs/gst/wayland/gstwllinuxdmabuf.c
+@@ -161,7 +161,7 @@ gst_wl_linux_dmabuf_construct_wl_buffer (GstBuffer * buf,
+     stride = get_drm_stride (finfo, strides, i);
+     if (gst_buffer_find_memory (buf, offset, 1, &mem_idx, &length, &skip)) {
+       GstMemory *m = gst_buffer_peek_memory (buf, mem_idx);
+-      gint fd = gst_dmabuf_memory_get_fd (m);
++      gint fd = gst_fd_memory_get_fd (m);
+       zwp_linux_buffer_params_v1_add (params, fd, i, m->offset + skip,
+           stride, modifier >> 32, modifier & G_GUINT64_CONSTANT (0x0ffffffff));
+     } else {
+diff --git a/gst-libs/gst/wayland/gstwlvideoformat.c b/gst-libs/gst/wayland/gstwlvideoformat.c
+index 1c0ea59..1800243 100644
+--- a/gst-libs/gst/wayland/gstwlvideoformat.c
++++ b/gst-libs/gst/wayland/gstwlvideoformat.c
+@@ -94,6 +94,7 @@ static const wl_VideoFormat wl_formats[] = {
+   {WL_SHM_FORMAT_YVU420, DRM_FORMAT_YVU420, GST_VIDEO_FORMAT_YV12},
+   {WL_SHM_FORMAT_YUV422, DRM_FORMAT_YUV422, GST_VIDEO_FORMAT_Y42B},
+   {WL_SHM_FORMAT_YUV444, DRM_FORMAT_YUV444, GST_VIDEO_FORMAT_v308},
++  {WL_SHM_FORMAT_NV12, DRM_FORMAT_NV12, GST_VIDEO_FORMAT_NV12_Q08C},
+ };
+ 
+ enum wl_shm_format
+diff --git a/gst-libs/gst/wayland/gstwlvideoformat.h b/gst-libs/gst/wayland/gstwlvideoformat.h
+index 5d7eb7c..a07e110 100644
+--- a/gst-libs/gst/wayland/gstwlvideoformat.h
++++ b/gst-libs/gst/wayland/gstwlvideoformat.h
+@@ -39,11 +39,13 @@ G_BEGIN_DECLS
+ #if G_BYTE_ORDER == G_BIG_ENDIAN
+ #define GST_WL_VIDEO_FORMATS "{ AYUV, RGBA, ARGB, BGRA, ABGR, P010_10LE, " \
+     "NV12_10LE40, v308, RGBx, xRGB, BGRx, xBGR, RGB, BGR, Y42B, NV16, NV61, " \
+-    "YUY2, YVYU, UYVY, I420, YV12, NV12, NV21, Y41B, YUV9, YVU9, BGR16, RGB16 }"
++    "YUY2, YVYU, UYVY, I420, YV12, NV12, NV21, Y41B, YUV9, YVU9, BGR16, RGB16, " \
++    "NV12_Q08C }"
+ #elif G_BYTE_ORDER == G_LITTLE_ENDIAN
+ #define GST_WL_VIDEO_FORMATS "{ AYUV, RGBA, ARGB, BGRA, ABGR, P010_10LE, " \
+     "NV12_10LE40, v308, RGBx, xRGB, BGRx, xBGR, RGB, BGR, Y42B, NV16, NV61, " \
+-    "YUY2, YVYU, UYVY, I420, YV12, NV12, NV21, Y41B, YUV9, YVU9, BGR16, RGB16 }"
++    "YUY2, YVYU, UYVY, I420, YV12, NV12, NV21, Y41B, YUV9, YVU9, BGR16, RGB16, " \
++    "NV12_Q08C }"
+ #endif
+ 
+ GST_WL_API
+-- 
+2.34.1
+

--- a/gstreamer1.0-plugins-bad/0005-waylandsink-make-sure-self-window-is-not-NULL-before.patch
+++ b/gstreamer1.0-plugins-bad/0005-waylandsink-make-sure-self-window-is-not-NULL-before.patch
@@ -1,0 +1,50 @@
+From e16036f2c80d561bb726b4bba581e1e634bd10ed Mon Sep 17 00:00:00 2001
+From: Michael Olbrich <m.olbrich@pengutronix.de>
+Date: Wed, 25 Jun 2025 16:17:58 +0200
+Subject: [PATCH 5/5] waylandsink: make sure self->window is not NULL before
+ using
+
+it
+
+self->window is created with the first frame, so it is not available when
+properties are set during construction of the element.
+Skip calling gst_wl_window_ensure_fullscreen() in this case.
+
+The window is already constructed with the current configured fullscreen state,
+nothing else in needed here.
+
+Without this, running e.g. 'gst-launch-1.0 -v videotestsrc ! waylandsink
+fullscreen=true' will result in:
+
+GStreamer-Wayland-CRITICAL **: 14:11:19.921: gst_wl_window_ensure_fullscreen: assertion 'self' failed
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9283>
+
+Upstream-Status: Backport [from version 1.27.1]
+---
+ ext/wayland/gstwaylandsink.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/ext/wayland/gstwaylandsink.c b/ext/wayland/gstwaylandsink.c
+index 1835db0..c57055e 100644
+--- a/ext/wayland/gstwaylandsink.c
++++ b/ext/wayland/gstwaylandsink.c
+@@ -211,10 +211,12 @@ gst_wayland_sink_set_fullscreen (GstWaylandSink * self, gboolean fullscreen)
+   if (fullscreen == self->fullscreen)
+     return;
+ 
+-  g_mutex_lock (&self->render_lock);
+   self->fullscreen = fullscreen;
+-  gst_wl_window_ensure_fullscreen (self->window, fullscreen);
+-  g_mutex_unlock (&self->render_lock);
++  if (self->window) {
++    g_mutex_lock (&self->render_lock);
++    gst_wl_window_ensure_fullscreen (self->window, fullscreen);
++    g_mutex_unlock (&self->render_lock);
++  }
+ }
+ 
+ static void
+-- 
+2.34.1
+


### PR DESCRIPTION
- waylandsink: Release pending buffers during PAUSED to READY state change
- waylandsink: support gap buffers
- wayland: Increase timeout limitation in gst_wl_window_new_toplevel
- wayland: Add support for NV12_Q08C (compressed 8-bit) format
- waylandsink: make sure self->window is not NULL before using it