### PR TITLE
gstreamer1.0-plugins-bad: Update NV12_Q08C patch to fix format check

### DIFF
--- a/gstreamer1.0-plugins-bad/0001-wayland-Add-support-for-NV12_Q08C-compressed-8-bit-f.patch
+++ b/gstreamer1.0-plugins-bad/0001-wayland-Add-support-for-NV12_Q08C-compressed-8-bit-f.patch
@@ -69,7 +69,7 @@ index 19a3e8c..030fe1b 100644
              &self->render_info, DRM_FORMAT_MOD_LINEAR))
        gst_video_info_dma_drm_init (&self->drm_info);
 +
-+    if (GST_VIDEO_INFO_FORMAT (&self->video_info) == GST_VIDEO_FORMAT_NV12_Q08C) {
++    if (GST_VIDEO_INFO_FORMAT (&self->render_info) == GST_VIDEO_FORMAT_NV12_Q08C) {
 +      self->drm_info.vinfo = self->render_info;
 +      self->drm_info.drm_fourcc = gst_video_dma_drm_fourcc_from_format (
 +          GST_VIDEO_FORMAT_NV12);


### PR DESCRIPTION
Update the existing patch 0001-wayland-Add-support-for-NV12_Q08C-compressed-8-bit-f.patch to use self->render_info instead of self->video_info when checking for NV12_Q08C format in gst_wayland_sink_set_caps().

The video_info field is assigned from render_info later in the function, so checking render_info directly ensures we use the newly parsed format information from the current caps for correct DRM format and modifier setup for NV12_Q08C buffers.

Note: No change to the patch header as this is a fix to the existing patch, which was denied upstream and it is maintained here.