### PR TITLE
gstreamer1.0-plugins-bad: update get_caps to include NV12_Q08C support

### DIFF
--- a/gstreamer1.0-plugins-bad/0004-wayland-Add-support-for-NV12_Q08C-compressed-8-bit-f.patch
+++ b/gstreamer1.0-plugins-bad/0004-wayland-Add-support-for-NV12_Q08C-compressed-8-bit-f.patch
@@ -1,8 +1,7 @@
-From 0d7d087ee2a0bf607e2314ac6967f839c282438f Mon Sep 17 00:00:00 2001
+From 2626020fb6f6028df88864818fe9110a4deb0d01 Mon Sep 17 00:00:00 2001
 From: Raja Ganapathi Busam <quic_rbusam@quicinc.com>
 Date: Thu, 17 Apr 2025 15:27:32 +0530
-Subject: [PATCH 4/5] wayland: Add support for NV12_Q08C (compressed 8-bit)
- format
+Subject: [PATCH 4/5] wayland: Add support for NV12_Q08C (compressed 8-bit) format
 
 - Add NV12_Q08C to static caps
 - Update the modifier value in set_caps for NV12_Q08C
@@ -11,18 +10,61 @@ Subject: [PATCH 4/5] wayland: Add support for NV12_Q08C (compressed 8-bit)
 Upstream-Status: Inappropriate [Qualcomm specific]
 
 Signed-off-by: Raja Ganapathi Busam <quic_rbusam@quicinc.com>
+Signed-off-by: Murali Krishna Bellamkonda <murabell@qti.qualcomm.com>
 ---
- ext/wayland/gstwaylandsink.c            | 14 +++++++++++++-
+ ext/wayland/gstwaylandsink.c            | 37 ++++++++++++++++++++++++-
  gst-libs/gst/wayland/gstwllinuxdmabuf.c |  2 +-
  gst-libs/gst/wayland/gstwlvideoformat.c |  1 +
- gst-libs/gst/wayland/gstwlvideoformat.h |  6 ++++--
- 4 files changed, 19 insertions(+), 4 deletions(-)
+ gst-libs/gst/wayland/gstwlvideoformat.h |  6 ++--
+ 4 files changed, 42 insertions(+), 4 deletions(-)
 
 diff --git a/ext/wayland/gstwaylandsink.c b/ext/wayland/gstwaylandsink.c
-index b76b48f..1835db0 100644
+index 19a3e8c..ad86804 100644
 --- a/ext/wayland/gstwaylandsink.c
 +++ b/ext/wayland/gstwaylandsink.c
-@@ -740,6 +740,17 @@ gst_wayland_sink_set_caps (GstBaseSink * bsink, GstCaps * caps)
+@@ -568,11 +568,30 @@ gst_wayland_sink_get_caps (GstBaseSink * bsink, GstCaps * filter)
+ 
+   if (self->display) {
+     GValue format_list = G_VALUE_INIT;
++    GValue value = G_VALUE_INIT;
++    gint j;
+ 
+     g_value_init (&format_list, GST_TYPE_LIST);
+ 
+     /* Add corresponding dmabuf formats */
+     gst_wl_display_fill_dmabuf_format_list (self->display, &format_list);
++
++    for (j = 0; j < gst_value_list_get_size (&format_list); j++) {
++      const GValue *vlist = gst_value_list_get_value (&format_list, j);
++      guint32 fourcc;
++      guint64 modifier;
++
++      fourcc = gst_video_dma_drm_fourcc_from_string (g_value_get_string (vlist),
++          &modifier);
++      if (fourcc == DRM_FORMAT_NV12 &&
++          modifier == DRM_FORMAT_MOD_QCOM_COMPRESSED) {
++        GST_DEBUG_OBJECT (self, "Found NV12_Q08C in DMAbuf format list");
++        g_value_init (&value, G_TYPE_STRING);
++        g_value_set_static_string (&value,
++            gst_video_format_to_string (GST_VIDEO_FORMAT_NV12_Q08C));
++      }
++    }
++
+     gst_structure_take_value (gst_caps_get_structure (caps, 0), "drm-format",
+         &format_list);
+ 
+@@ -580,6 +599,10 @@ gst_wayland_sink_get_caps (GstBaseSink * bsink, GstCaps * filter)
+ 
+     /* Add corresponding shm formats */
+     gst_wl_display_fill_shm_format_list (self->display, &format_list);
++    if (G_VALUE_HOLDS_STRING (&value)) {
++      GST_DEBUG_OBJECT (self, "Adding NV12_Q08C to SHM format list");
++      gst_value_list_append_and_take_value (&format_list, &value);
++    }
+     gst_structure_take_value (gst_caps_get_structure (caps, 1), "format",
+         &format_list);
+ 
+@@ -706,6 +729,17 @@ gst_wayland_sink_set_caps (GstBaseSink * bsink, GstCaps * caps)
      if (!gst_video_info_dma_drm_from_video_info (&self->drm_info,
              &self->video_info, DRM_FORMAT_MOD_LINEAR))
        gst_video_info_dma_drm_init (&self->drm_info);
@@ -40,7 +82,7 @@ index b76b48f..1835db0 100644
    }
  
    self->video_info_changed = TRUE;
-@@ -936,7 +947,8 @@ gst_wayland_sink_show_frame (GstVideoSink * vsink, GstBuffer * buffer)
+@@ -895,7 +929,8 @@ gst_wayland_sink_show_frame (GstVideoSink * vsink, GstBuffer * buffer)
      guint i, nb_dmabuf = 0;
  
      for (i = 0; i < gst_buffer_n_memory (buffer); i++)


### PR DESCRIPTION
- Update gst_wayland_sink_get_caps() to detect NV12 with QCOM compressed modifier in dmabuf formats and propagate NV12_Q08C into the SHM caps list when supported.
- This change is migrated from 1.26.9 patches to 1.26.2.